### PR TITLE
fix: Fix component naming scheme to allow numbers from 0 to 9

### DIFF
--- a/plugins/dql-backend/src/service/queryExecutor.ts
+++ b/plugins/dql-backend/src/service/queryExecutor.ts
@@ -9,12 +9,12 @@ const componentQueryVariablesSchema = z.object({
   componentNamespace: z
     .string()
     .max(63)
-    .regex(/^[A-Za-z1-9\-]+$/),
+    .regex(/^[A-Za-z0-9\-]+$/),
   // see https://backstage.io/docs/features/software-catalog/descriptor-format#name-required
   componentName: z
     .string()
     .max(63)
-    .regex(/^[A-Za-z1-9\-_\.]+$/),
+    .regex(/^[A-Za-z0-9\-_\.]+$/),
 });
 
 type ComponentQueryVariables = z.infer<typeof componentQueryVariablesSchema>;


### PR DESCRIPTION
This fixes a bug where the Dynatrace plugin doesn't work for Backstage entities with zeros in their name