### PR TITLE
chore: use "Dynatrace DQL Plugin name"

### DIFF
--- a/plugins/dql-backend/README.md
+++ b/plugins/dql-backend/README.md
@@ -1,4 +1,4 @@
-# Dynatrace Kubernetes Backend
+# Dynatrace DQL Plugin Backend
 
 Package name: `@dynatrace/backstage-plugin-dql-backend`
 

--- a/plugins/dql-common/README.md
+++ b/plugins/dql-common/README.md
@@ -1,4 +1,4 @@
-# Dynatrace Kubernetes Commons
+# Dynatrace DQL Plugin Commons
 
 Package name: `@dynatrace/backstage-plugin-dql-common`
 


### PR DESCRIPTION
The Readmes of the backend and common plugins mentioned "Kubernetes" in their titles. However, we are not limited to Kubernetes-related queries and, hence, we agreed to rename it to DQL.