### PR TITLE
fix: kubernetes log query

### DIFF
--- a/plugins/dql-backend/src/service/queries.ts
+++ b/plugins/dql-backend/src/service/queries.ts
@@ -17,7 +17,11 @@ export const dynatraceQueries: Record<string, string | undefined> = {
     | lookup [ fetch events, from: -30m | filter event.kind=="SECURITY_EVENT" | filter event.category=="VULNERABILITY_MANAGEMENT" | filter event.provider=="Dynatrace" | filter event.type=="VULNERABILITY_STATE_REPORT_EVENT" | filter in(vulnerability.stack,{"CODE_LIBRARY","SOFTWARE","CONTAINER_ORCHESTRATION"}) | filter event.level=="ENTITY" | summarize { workloadId=arrayFirst(takeFirst(related_entities.kubernetes_workloads.ids)), vulnerability.stack=takeFirst(vulnerability.stack)}, by: {vulnerability.id, affected_entity.id} | summarize { Vulnerabilities=count() }, by: {workloadId}], sourceField:id, lookupField:workloadId, fields:{Vulnerabilities}
     | fieldsAdd Vulnerabilities=coalesce(Vulnerabilities,0)
     | filter workload.labels[\`backstage.io/component\`] == "\${componentNamespace}.\${componentName}"
+    | fieldsAdd Logs = record({type="link", text="Show logs", url=concat(
+      "\${environmentUrl}",
+      "/ui/apps/dynatrace.notebooks/intent/view-query#%7B%22dt.query%22%3A%22fetch%20logs%20%7C%20filter%20matchesValue(dt.entity.cloud_application%2C%5C%22",
+      id,
+      "%5C%22)%20%7C%20sort%20timestamp%20desc%22%2C%22title%22%3A%22Logs%22%7D")})
     | fieldsRemove id, deploymentVersion, podVersion, name, workload.labels, cluster.id, namespace.id
-    | fieldsAdd Logs = record({type="link", text="Show logs", url="\${environmentUrl}/ui/apps/dynatrace.notebooks/intent/view-query#%7B%22dt.query%22%3A%22fetch%20logs%20%7C%20filter%20matchesValue(dt.entity.cloud_application_instance%2C%20%5C%22CLOUD_APPLICATION_INSTANCE-A414AA7D3B688EA1%5C%22)%20%7C%20sort%20timestamp%20desc%22%2C%22title%22%3A%22Logs%22%7D"})
     | fieldsAdd Environment = "\${environmentName}"`,
 };


### PR DESCRIPTION
For the "Logs" column of the kubernetes query, a static id `CLOUD_APPLICATION_INSTANCE-A414AA7D3B688EA1` was used and `cloud_application_instance` was queried instead of `cloud_application`