### PR TITLE
chore:  CA-9995 add referer header to DQL execution

### DIFF
--- a/plugins/dql-backend/src/utils/dtFetch.ts
+++ b/plugins/dql-backend/src/utils/dtFetch.ts
@@ -26,6 +26,7 @@ export const dtFetch = (
   options.headers = {
     ...options.headers,
     'User-Agent': userAgent,
+    Referer: 'backstage-plugin',
   };
 
   return fetch(url, options);


### PR DESCRIPTION
# Introduction

Adds the Referer header "backstage-plugin" to the DQL execution.

There is another "fetch", which is not dtFetch but this one can be ignored, because this is the backstage-client request to the backstage-backend
