### PR TITLE
chore: adopt kubernetes dql

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,14 +204,14 @@ backstage.io/kubernetes-namespace: namespace
 backstage.io/kubernetes-label-selector: stage=hardening,name=frontend
 ```
 
-- The annotation `backstage.io/kubernetes-id` will look for the kubernetes label
+- The annotation `backstage.io/kubernetes-id` will look for the Kubernetes label
   `backstage.io/kubernetes-id`.
 - The annotation `backstage.io/kubernetes-namespace` will look for the
-  kubernetes namespace.
+  Kubernetes namespace.
 - The annotation `backstage.io/kubernetes-label-selector` will look for the
   labels defined in it. So
   `backstage.io/kubernetes-label-selector: stage=hardening,name=frontend` will
-  look for a kubernetes label `stage` with the value `hardening` and a label
+  look for a Kubernetes label `stage` with the value `hardening` and a label
   `name` with the value `frontend`.
 
 If a `backstage.io/kubernetes-label-selector` is given,

--- a/README.md
+++ b/README.md
@@ -192,13 +192,31 @@ deployments in your Dynatrace environment.
 />
 ```
 
-_Convention:_ Kubernetes pods with a `backstage.io/component` label will be
-listed for the corresponding Backstage component if they are properly annotated
-in the deployment descriptor:
+_Convention:_ Kubernetes pods will be listed for the corresponding Backstage
+component if they are properly annotated in the deployment descriptor.
+
+Example:
 
 ```yaml
-backstage.io/component: <backstage-namespace>.<backstage-component-name>
+backstage.io/kubernetes-id: kubernetesid
+backstage.io/kubernetes-namespace: namespace
+backstage.io/kubernetes-label-selector: stage=hardening,name=frontend
 ```
+
+- The annotation `backstage.io/kubernetes-id` will look for the kubernetes label
+  `backstage.io/kubernetes-id`.
+- The annotation `backstage.io/kubernetes-namespace` will look for the
+  kubernetes namespace.
+- The annotation `backstage.io/kubernetes-label-selector` will look for the
+  labels defined in it. So `stage=hardening,name=frontend` will look for a
+  kubernetes label `stage` with the value `hardening` and a label `name` with
+  the value `frontend`.
+
+If a `backstage.io/kubernetes-label-selector` is given,
+`backstage.io/kubernetes-id` is ignored.
+
+If no namespace is given, it looks for all namespaces. There is no fallback to
+`default`.
 
 The query for fetching the monitoring data for Kubernetes deployments is defined
 here:

--- a/README.md
+++ b/README.md
@@ -193,7 +193,8 @@ deployments in your Dynatrace environment.
 ```
 
 _Convention:_ Kubernetes pods will be listed for the corresponding Backstage
-component if they are properly annotated in the deployment descriptor.
+component if they are properly annotated in the deployment descriptor. See
+[annotations](https://backstage.io/docs/features/software-catalog/descriptor-format/#annotations-optional).
 
 Example:
 
@@ -208,9 +209,10 @@ backstage.io/kubernetes-label-selector: stage=hardening,name=frontend
 - The annotation `backstage.io/kubernetes-namespace` will look for the
   kubernetes namespace.
 - The annotation `backstage.io/kubernetes-label-selector` will look for the
-  labels defined in it. So `stage=hardening,name=frontend` will look for a
-  kubernetes label `stage` with the value `hardening` and a label `name` with
-  the value `frontend`.
+  labels defined in it. So
+  `backstage.io/kubernetes-label-selector: stage=hardening,name=frontend` will
+  look for a kubernetes label `stage` with the value `hardening` and a label
+  `name` with the value `frontend`.
 
 If a `backstage.io/kubernetes-label-selector` is given,
 `backstage.io/kubernetes-id` is ignored.

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -3,6 +3,8 @@ kind: Component
 metadata:
   name: demo-backstage
   description: Backstage Demo instance.
+  annotations:
+    backstage.io/kubernetes-id: kubernetescustom
 spec:
   type: website
   owner: user:default/mjakl

--- a/packages/backend/src/plugins/dynatrace-dql.ts
+++ b/packages/backend/src/plugins/dynatrace-dql.ts
@@ -20,8 +20,5 @@ import { Router } from 'express';
 export default async function createPlugin(
   env: PluginEnvironment,
 ): Promise<Router> {
-  return await createRouter({
-    logger: env.logger,
-    config: env.config,
-  });
+  return await createRouter(env);
 }

--- a/plugins/dql-backend/src/service/queries.test.ts
+++ b/plugins/dql-backend/src/service/queries.test.ts
@@ -1,0 +1,99 @@
+/**
+ * @license
+ * Copyright 2024 Dynatrace LLC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { dynatraceQueries, DynatraceQueryKeys } from './queries';
+import { Entity } from '@backstage/catalog-model';
+
+describe('queries', () => {
+  const getEntity = (annotations?: Record<string, string>): Entity => ({
+    apiVersion: '1.0.0',
+    kind: 'component',
+    metadata: { name: 'componentName', annotations },
+  });
+  const defaultApiConfig = {
+    environmentName: 'environment',
+    environmentUrl: 'url',
+  };
+
+  describe(DynatraceQueryKeys.KUBERNETES_DEPLOYMENTS, () => {
+    it('should fail if neither the label selector nor the kubernetes id annotation is provided', () => {
+      // act, assert
+      expect(() =>
+        dynatraceQueries[DynatraceQueryKeys.KUBERNETES_DEPLOYMENTS](
+          getEntity(),
+          defaultApiConfig,
+        ),
+      ).toThrow();
+    });
+
+    it('should return the query without the kubernetesId filter if a label selector is provided', () => {
+      // act
+      const query = dynatraceQueries[DynatraceQueryKeys.KUBERNETES_DEPLOYMENTS](
+        getEntity({
+          'backstage.io/kubernetes-id': 'kubernetesId',
+          'backstage.io/kubernetes-label-selector': 'label=value',
+        }),
+        defaultApiConfig,
+      );
+
+      // assert
+      expect(query).not.toContain(
+        '| filter workload.labels[`backstage.io/kubernetes-id`] == "kubernetesId"',
+      );
+      expect(query).toContain('| filter workload.labels[`label`] == "value"');
+    });
+
+    it('should return the query with the kubernetesId filter ', () => {
+      // act
+      const query = dynatraceQueries[DynatraceQueryKeys.KUBERNETES_DEPLOYMENTS](
+        getEntity({ 'backstage.io/kubernetes-id': 'kubernetesId' }),
+        defaultApiConfig,
+      );
+
+      // assert
+      expect(query).toContain(
+        '| filter workload.labels[`backstage.io/kubernetes-id`] == "kubernetesId"',
+      );
+    });
+
+    it('should return the query with the namespace filter', () => {
+      // act
+      const query = dynatraceQueries[DynatraceQueryKeys.KUBERNETES_DEPLOYMENTS](
+        getEntity({
+          'backstage.io/kubernetes-id': 'kubernetesId',
+          'backstage.io/kubernetes-namespace': 'namespace',
+        }),
+        defaultApiConfig,
+      );
+
+      // assert
+      expect(query).toContain('| filter Namespace == "namespace"');
+    });
+
+    it('should return the query with the label selector filter', () => {
+      // act
+      const query = dynatraceQueries[DynatraceQueryKeys.KUBERNETES_DEPLOYMENTS](
+        getEntity({
+          'backstage.io/kubernetes-label-selector': 'label=value',
+          'backstage.io/kubernetes-namespace': 'namespace',
+        }),
+        defaultApiConfig,
+      );
+
+      // assert
+      expect(query).toContain('| filter workload.labels[`label`] == "value"');
+    });
+  });
+});

--- a/plugins/dql-backend/src/service/queries.ts
+++ b/plugins/dql-backend/src/service/queries.ts
@@ -32,7 +32,9 @@ export const dynatraceQueries: Record<string, string | undefined> = {
     | fieldsAdd Problems=coalesce(Problems,0)
     | lookup [ fetch events, from: -30m | filter event.kind=="SECURITY_EVENT" | filter event.category=="VULNERABILITY_MANAGEMENT" | filter event.provider=="Dynatrace" | filter event.type=="VULNERABILITY_STATE_REPORT_EVENT" | filter in(vulnerability.stack,{"CODE_LIBRARY","SOFTWARE","CONTAINER_ORCHESTRATION"}) | filter event.level=="ENTITY" | summarize { workloadId=arrayFirst(takeFirst(related_entities.kubernetes_workloads.ids)), vulnerability.stack=takeFirst(vulnerability.stack)}, by: {vulnerability.id, affected_entity.id} | summarize { Vulnerabilities=count() }, by: {workloadId}], sourceField:id, lookupField:workloadId, fields:{Vulnerabilities}
     | fieldsAdd Vulnerabilities=coalesce(Vulnerabilities,0)
-    \${additionalFilter}
+    | filter "\${labelFilter}" == "" AND workload.labels[\`backstage.io/kubernetes-id\`] == "\${kubernetesId}" OR "\${kubernetesId}" == "" 
+    | filter Namespace == "\${componentNamespace}" OR "\${componentNamespace}" == ""
+    \${labelFilter}
     | fieldsAdd Logs = record({type="link", text="Show logs", url=concat(
       "\${environmentUrl}",
       "/ui/apps/dynatrace.notebooks/intent/view-query#%7B%22dt.query%22%3A%22fetch%20logs%20%7C%20filter%20matchesValue(dt.entity.cloud_application%2C%5C%22",

--- a/plugins/dql-backend/src/service/queries.ts
+++ b/plugins/dql-backend/src/service/queries.ts
@@ -13,9 +13,53 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import { generateKubernetesSelectorFilter } from '../utils/labelSelectorParser';
+import { Entity } from '@backstage/catalog-model';
 
-export const dynatraceQueries: Record<string, string | undefined> = {
-  'kubernetes-deployments': `
+export enum DynatraceQueryKeys {
+  KUBERNETES_DEPLOYMENTS = 'kubernetes-deployments',
+}
+
+interface ApiConfig {
+  environmentName: string;
+  environmentUrl: string;
+}
+
+export const isValidDynatraceQueryKey = (
+  key: string,
+): key is DynatraceQueryKeys => key in dynatraceQueries;
+
+export const dynatraceQueries: Record<
+  DynatraceQueryKeys,
+  (entity: Entity, apiConfig: ApiConfig) => string
+> = {
+  [DynatraceQueryKeys.KUBERNETES_DEPLOYMENTS]: (entity, apiConfig) => {
+    const labelSelector =
+      entity.metadata.annotations?.['backstage.io/kubernetes-label-selector'];
+    const kubernetesId =
+      entity.metadata.annotations?.['backstage.io/kubernetes-id'];
+    const namespace =
+      entity.metadata.annotations?.['backstage.io/kubernetes-namespace'];
+
+    const filterLabel = labelSelector
+      ? generateKubernetesSelectorFilter(labelSelector)
+      : '';
+    // if a label filter is given, the id is ignored
+    const filterKubernetesId =
+      filterLabel || !kubernetesId
+        ? ''
+        : `| filter workload.labels[\`backstage.io/kubernetes-id\`] == "${kubernetesId}"`;
+    const filterNamespace = namespace
+      ? `| filter Namespace == "${namespace}"`
+      : '';
+
+    if (!filterKubernetesId && !filterLabel) {
+      throw new Error(
+        'One of the component annotations is required: "backstage.io/kubernetes-id" or "backstage.io/kubernetes-label-selector"',
+      );
+    }
+
+    return `
     fetch dt.entity.cloud_application, from: -10m
     | fields id,
         name = entity.name,
@@ -25,21 +69,22 @@ export const dynatraceQueries: Record<string, string | undefined> = {
         namespace.id = belongs_to[dt.entity.cloud_application_namespace]
     | sort upper(name) asc
     | lookup [fetch dt.entity.cloud_application_instance, from: -10m | fields matchedId = instance_of[dt.entity.cloud_application], podVersion = cloudApplicationLabels[\`app.kubernetes.io/version\`]], sourceField:id, lookupField:matchedId, fields:{podVersion}
-    | fieldsAdd Workload = record({type="link", text=name, url=concat("\${environmentUrl}/ui/apps/dynatrace.kubernetes/resources/pod?entityId=", id)})
+    | fieldsAdd Workload = record({type="link", text=name, url=concat("${apiConfig.environmentUrl}/ui/apps/dynatrace.kubernetes/resources/pod?entityId=", id)})
     | lookup [fetch dt.entity.kubernetes_cluster, from: -10m | fields id, Cluster = entity.name],sourceField:cluster.id, lookupField:id, fields:{Cluster}
     | lookup [fetch dt.entity.cloud_application_namespace, from: -10m | fields id, Namespace = entity.name], sourceField:namespace.id, lookupField:id, fields:{Namespace}
     | lookup [fetch events, from: -30m | filter event.kind == "DAVIS_PROBLEM" | fieldsAdd affected_entity_id = affected_entity_ids[0] | summarize collectDistinct(event.status), by:{display_id, affected_entity_id}, alias:problem_status | filter NOT in(problem_status, "CLOSED") | summarize Problems = count(), by:{affected_entity_id}], sourceField:id, lookupField:affected_entity_id, fields:{Problems}
     | fieldsAdd Problems=coalesce(Problems,0)
     | lookup [ fetch events, from: -30m | filter event.kind=="SECURITY_EVENT" | filter event.category=="VULNERABILITY_MANAGEMENT" | filter event.provider=="Dynatrace" | filter event.type=="VULNERABILITY_STATE_REPORT_EVENT" | filter in(vulnerability.stack,{"CODE_LIBRARY","SOFTWARE","CONTAINER_ORCHESTRATION"}) | filter event.level=="ENTITY" | summarize { workloadId=arrayFirst(takeFirst(related_entities.kubernetes_workloads.ids)), vulnerability.stack=takeFirst(vulnerability.stack)}, by: {vulnerability.id, affected_entity.id} | summarize { Vulnerabilities=count() }, by: {workloadId}], sourceField:id, lookupField:workloadId, fields:{Vulnerabilities}
     | fieldsAdd Vulnerabilities=coalesce(Vulnerabilities,0)
-    | filter "\${labelFilter}" == "" AND workload.labels[\`backstage.io/kubernetes-id\`] == "\${kubernetesId}" OR "\${kubernetesId}" == "" 
-    | filter Namespace == "\${componentNamespace}" OR "\${componentNamespace}" == ""
-    \${labelFilter}
+    ${filterKubernetesId} 
+    ${filterNamespace} 
+    ${filterLabel}
     | fieldsAdd Logs = record({type="link", text="Show logs", url=concat(
-      "\${environmentUrl}",
+      "${apiConfig.environmentUrl}",
       "/ui/apps/dynatrace.notebooks/intent/view-query#%7B%22dt.query%22%3A%22fetch%20logs%20%7C%20filter%20matchesValue(dt.entity.cloud_application%2C%5C%22",
       id,
       "%5C%22)%20%7C%20sort%20timestamp%20desc%22%2C%22title%22%3A%22Logs%22%7D")})
     | fieldsRemove id, deploymentVersion, podVersion, name, workload.labels, cluster.id, namespace.id
-    | fieldsAdd Environment = "\${environmentName}"`,
+    | fieldsAdd Environment = "${apiConfig.environmentName}"`;
+  },
 };

--- a/plugins/dql-backend/src/service/queries.ts
+++ b/plugins/dql-backend/src/service/queries.ts
@@ -32,7 +32,7 @@ export const dynatraceQueries: Record<string, string | undefined> = {
     | fieldsAdd Problems=coalesce(Problems,0)
     | lookup [ fetch events, from: -30m | filter event.kind=="SECURITY_EVENT" | filter event.category=="VULNERABILITY_MANAGEMENT" | filter event.provider=="Dynatrace" | filter event.type=="VULNERABILITY_STATE_REPORT_EVENT" | filter in(vulnerability.stack,{"CODE_LIBRARY","SOFTWARE","CONTAINER_ORCHESTRATION"}) | filter event.level=="ENTITY" | summarize { workloadId=arrayFirst(takeFirst(related_entities.kubernetes_workloads.ids)), vulnerability.stack=takeFirst(vulnerability.stack)}, by: {vulnerability.id, affected_entity.id} | summarize { Vulnerabilities=count() }, by: {workloadId}], sourceField:id, lookupField:workloadId, fields:{Vulnerabilities}
     | fieldsAdd Vulnerabilities=coalesce(Vulnerabilities,0)
-    | filter workload.labels[\`backstage.io/component\`] == "\${componentNamespace}.\${componentName}"
+    \${additionalFilter}
     | fieldsAdd Logs = record({type="link", text="Show logs", url=concat(
       "\${environmentUrl}",
       "/ui/apps/dynatrace.notebooks/intent/view-query#%7B%22dt.query%22%3A%22fetch%20logs%20%7C%20filter%20matchesValue(dt.entity.cloud_application%2C%5C%22",

--- a/plugins/dql-backend/src/service/queryCompiler.ts
+++ b/plugins/dql-backend/src/service/queryCompiler.ts
@@ -16,11 +16,11 @@
 
 export function compileDqlQuery(
   queryToCompile: string,
-  variables: Record<string, unknown>,
+  variables: Record<string, string | undefined>,
 ): string {
   return Array.from(Object.entries(variables)).reduce(
     (query: string, [variable, value]) =>
-      query.replaceAll(`\${${variable}}`, String(value)),
+      query.replaceAll(`\${${variable}}`, String(value ?? '')),
     queryToCompile,
   );
 }

--- a/plugins/dql-backend/src/service/queryExecutor.test.ts
+++ b/plugins/dql-backend/src/service/queryExecutor.test.ts
@@ -14,12 +14,18 @@
  * limitations under the License.
  */
 import { QueryExecutor } from './queryExecutor';
+import { Entity } from '@backstage/catalog-model';
 
 describe('queryExecutor', () => {
   const executor = new QueryExecutor([], { 'my.id': 'myQuery' });
   const inputVariables = {
     componentNamespace: 'namespace',
     componentName: 'name',
+  };
+  const entity: Entity = {
+    apiVersion: '1.0.0',
+    kind: 'component',
+    metadata: { name: 'componentName' },
   };
 
   describe('Invalid IDs', () => {
@@ -33,7 +39,7 @@ describe('queryExecutor', () => {
     it('should throw an error if a Dynatrace query is undefined', async () => {
       // assert
       await expect(() =>
-        executor.executeDynatraceQuery('not.existing', inputVariables),
+        executor.executeDynatraceQuery('not.existing', entity),
       ).rejects.toThrow();
     });
   });
@@ -50,7 +56,7 @@ describe('queryExecutor', () => {
       // act
       const result = await executor.executeDynatraceQuery(
         'kubernetes-deployments',
-        inputVariables,
+        entity,
       );
       // assert
       expect(result).toEqual([]);

--- a/plugins/dql-backend/src/service/queryExecutor.ts
+++ b/plugins/dql-backend/src/service/queryExecutor.ts
@@ -19,20 +19,22 @@ import { compileDqlQuery } from './queryCompiler';
 import { TabularData } from '@dynatrace/backstage-plugin-dql-common';
 import { z } from 'zod';
 
-const componentQueryVariablesSchema = z.object({
-  // see https://backstage.io/docs/features/software-catalog/descriptor-format#namespace-optional
-  componentNamespace: z
-    .string()
-    .max(63)
-    .regex(/^[A-Za-z0-9\-]+$/)
-    .optional(), // optional because kubernetes query does not need a namespace (may query several namespaces)
-  // see https://backstage.io/docs/features/software-catalog/descriptor-format#name-required
-  componentName: z
-    .string()
-    .max(63)
-    .regex(/^[A-Za-z0-9\-_\.]+$/),
-  additionalFilter: z.string().default(''),
-});
+const componentQueryVariablesSchema = z
+  .object({
+    // see https://backstage.io/docs/features/software-catalog/descriptor-format#namespace-optional
+    componentNamespace: z
+      .string()
+      .max(63)
+      .regex(/^[A-Za-z0-9\-]+$/)
+      .optional(), // optional because kubernetes query does not need a namespace (may query several namespaces)
+    // see https://backstage.io/docs/features/software-catalog/descriptor-format#name-required
+    componentName: z
+      .string()
+      .max(63)
+      .regex(/^[A-Za-z0-9\-_\.]+$/),
+    additionalFilter: z.string().default(''),
+  })
+  .catchall(z.string().or(z.undefined())); // catchall is basically [key: string]: string | undefined
 
 type ComponentQueryVariables = z.input<typeof componentQueryVariablesSchema>;
 

--- a/plugins/dql-backend/src/service/queryExecutor.ts
+++ b/plugins/dql-backend/src/service/queryExecutor.ts
@@ -30,10 +30,7 @@ const componentQueryVariablesSchema = z.object({
     .string()
     .max(63)
     .regex(/^[A-Za-z0-9\-_\.]+$/),
-  additionalFilter: z
-    .string()
-    .optional()
-    .transform(filter => filter ?? ''),
+  additionalFilter: z.string().default(''),
 });
 
 type ComponentQueryVariables = z.input<typeof componentQueryVariablesSchema>;

--- a/plugins/dql-backend/src/service/queryExecutor.ts
+++ b/plugins/dql-backend/src/service/queryExecutor.ts
@@ -24,7 +24,8 @@ const componentQueryVariablesSchema = z.object({
   componentNamespace: z
     .string()
     .max(63)
-    .regex(/^[A-Za-z0-9\-]+$/),
+    .regex(/^[A-Za-z0-9\-]+$/)
+    .optional(), // optional because kubernetes query does not need a namespace (may query several namespaces)
   // see https://backstage.io/docs/features/software-catalog/descriptor-format#name-required
   componentName: z
     .string()

--- a/plugins/dql-backend/src/service/queryExecutor.ts
+++ b/plugins/dql-backend/src/service/queryExecutor.ts
@@ -30,9 +30,13 @@ const componentQueryVariablesSchema = z.object({
     .string()
     .max(63)
     .regex(/^[A-Za-z0-9\-_\.]+$/),
+  additionalFilter: z
+    .string()
+    .optional()
+    .transform(filter => filter ?? ''),
 });
 
-type ComponentQueryVariables = z.infer<typeof componentQueryVariablesSchema>;
+type ComponentQueryVariables = z.input<typeof componentQueryVariablesSchema>;
 
 export class QueryExecutor {
   constructor(
@@ -66,11 +70,11 @@ export class QueryExecutor {
     dqlQuery: string,
     variables: ComponentQueryVariables,
   ): Promise<TabularData> {
-    componentQueryVariablesSchema.parse(variables);
+    const parsedVariables = componentQueryVariablesSchema.parse(variables);
 
     const results$ = this.apis.map(api => {
       const compiledQuery = compileDqlQuery(dqlQuery, {
-        ...variables,
+        ...parsedVariables,
         environmentName: api.environmentName,
         environmentUrl: api.environmentUrl,
       });

--- a/plugins/dql-backend/src/service/router.test.ts
+++ b/plugins/dql-backend/src/service/router.test.ts
@@ -16,6 +16,7 @@
 import { createRouter } from './router';
 import { getVoidLogger } from '@backstage/backend-common';
 import { MockConfigApi } from '@backstage/test-utils';
+import { PluginEnvironment } from 'backend/src/types';
 import express from 'express';
 
 describe('createRouter', () => {
@@ -24,6 +25,14 @@ describe('createRouter', () => {
   beforeAll(async () => {
     const router = await createRouter({
       logger: getVoidLogger(),
+      discovery: {
+        async getBaseUrl(): Promise<string> {
+          return '';
+        },
+        async getExternalBaseUrl(): Promise<string> {
+          return '';
+        },
+      },
       config: new MockConfigApi({
         dynatrace: {
           environments: [
@@ -38,7 +47,7 @@ describe('createRouter', () => {
           ],
         },
       }),
-    });
+    } as unknown as PluginEnvironment);
     app = express().use(router);
   });
 

--- a/plugins/dql-backend/src/service/router.ts
+++ b/plugins/dql-backend/src/service/router.ts
@@ -14,10 +14,8 @@
  * limitations under the License.
  */
 import { parseCustomQueries, parseEnvironments } from '../utils/configParser';
-import {
-  generateComplexFilter,
-  validateQueryParameters,
-} from '../utils/routeUtils';
+import { generateKubernetesSelectorFilter } from '../utils/labelSelectorParser';
+import { validateQueryParameters } from '../utils/routeUtils';
 import { QueryExecutor } from './queryExecutor';
 import { errorHandler } from '@backstage/backend-common';
 import { Config } from '@backstage/config';
@@ -57,11 +55,11 @@ export const createRouter = async ({
       {
         componentName: componentName as string,
         componentNamespace: componentNamespace as string | undefined,
-        additionalFilter: generateComplexFilter(
-          kubernetesId,
-          labelSelector,
-          componentNamespace,
-        ),
+        kubernetesId: kubernetesId as string | undefined,
+        labelFilter:
+          labelSelector && typeof labelSelector === 'string'
+            ? generateKubernetesSelectorFilter(labelSelector)
+            : undefined,
       },
     );
     res.json(deployments);

--- a/plugins/dql-backend/src/service/router.ts
+++ b/plugins/dql-backend/src/service/router.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 import { parseCustomQueries, parseEnvironments } from '../utils/configParser';
+import { generateKubernetesSelectorFilter } from '../utils/labelSelectorParser';
 import { QueryExecutor } from './queryExecutor';
 import { errorHandler } from '@backstage/backend-common';
 import { Config } from '@backstage/config';
@@ -45,11 +46,26 @@ export const createRouter = async ({
   });
 
   router.get('/dynatrace/:queryId', async (req, res) => {
+    const { kubernetesId, labelSelector, componentNamespace, componentName } =
+      req.query;
+    const filters: string[] = [];
+    if (kubernetesId && typeof kubernetesId === 'string') {
+      filters.push(
+        `| filter workload.labels[\`backstage.io/kubernetes-id\`] == ${kubernetesId}`,
+      );
+    }
+    if (labelSelector && typeof labelSelector === 'string') {
+      filters.push(generateKubernetesSelectorFilter(labelSelector));
+    }
+    if (componentNamespace && typeof componentNamespace === 'string') {
+      filters.push(`| filter namespace.id == ${componentNamespace}`);
+    }
     const deployments = await queryExecutor.executeDynatraceQuery(
       req.params.queryId,
       {
-        componentNamespace: req.query.componentNamespace as string,
-        componentName: req.query.componentName as string,
+        componentName: componentName as string,
+        componentNamespace: componentNamespace as string,
+        additionalFilter: filters.join('\n'),
       },
     );
     res.json(deployments);

--- a/plugins/dql-backend/src/service/router.ts
+++ b/plugins/dql-backend/src/service/router.ts
@@ -46,13 +46,8 @@ export const createRouter = async ({
   });
 
   router.get('/dynatrace/:queryId', async (req, res) => {
-    const {
-      kubernetesId,
-      labelSelector,
-      namespaceSelector,
-      componentNamespace,
-      componentName,
-    } = req.query;
+    const { kubernetesId, labelSelector, componentNamespace, componentName } =
+      req.query;
     const deployments = await queryExecutor.executeDynatraceQuery(
       req.params.queryId,
       {
@@ -61,7 +56,7 @@ export const createRouter = async ({
         additionalFilter: generateComplexFilter(
           kubernetesId,
           labelSelector,
-          namespaceSelector,
+          componentNamespace,
         ),
       },
     );

--- a/plugins/dql-backend/src/service/router.ts
+++ b/plugins/dql-backend/src/service/router.ts
@@ -46,8 +46,13 @@ export const createRouter = async ({
   });
 
   router.get('/dynatrace/:queryId', async (req, res) => {
-    const { kubernetesId, labelSelector, componentNamespace, componentName } =
-      req.query;
+    const {
+      kubernetesId,
+      labelSelector,
+      namespaceSelector,
+      componentNamespace,
+      componentName,
+    } = req.query;
     const deployments = await queryExecutor.executeDynatraceQuery(
       req.params.queryId,
       {
@@ -56,7 +61,7 @@ export const createRouter = async ({
         additionalFilter: generateComplexFilter(
           kubernetesId,
           labelSelector,
-          componentNamespace,
+          namespaceSelector,
         ),
       },
     );

--- a/plugins/dql-backend/src/service/router.ts
+++ b/plugins/dql-backend/src/service/router.ts
@@ -14,53 +14,40 @@
  * limitations under the License.
  */
 import { parseCustomQueries, parseEnvironments } from '../utils/configParser';
-import { generateKubernetesSelectorFilter } from '../utils/labelSelectorParser';
-import { validateQueryParameters } from '../utils/routeUtils';
+import { getEntityFromRequest } from '../utils/routeUtils';
 import { QueryExecutor } from './queryExecutor';
 import { errorHandler } from '@backstage/backend-common';
-import { Config } from '@backstage/config';
+import { CatalogClient } from '@backstage/catalog-client';
+import { PluginEnvironment } from 'backend/src/types';
 import express from 'express';
 import Router from 'express-promise-router';
-import { Logger } from 'winston';
-
-export type RouterOptions = {
-  logger: Logger;
-  config: Config;
-};
 
 export const createRouter = async ({
   config,
-}: RouterOptions): Promise<express.Router> => {
+  discovery,
+}: PluginEnvironment): Promise<express.Router> => {
   const apis = parseEnvironments(config);
   const customQueries = parseCustomQueries(config);
   const queryExecutor = new QueryExecutor(apis, customQueries);
+  const catalogClient = new CatalogClient({ discoveryApi: discovery });
 
   const router = Router();
   router.use(express.json());
 
   router.get('/custom/:queryId', async (req, res) => {
+    const entity = await getEntityFromRequest(req, catalogClient);
     const result = await queryExecutor.executeCustomQuery(req.params.queryId, {
-      componentNamespace: req.query.componentNamespace as string,
-      componentName: req.query.componentName as string,
+      componentNamespace: entity.metadata.namespace ?? 'default',
+      componentName: entity.metadata.name,
     });
     return res.json(result);
   });
 
   router.get('/dynatrace/:queryId', async (req, res) => {
-    const { kubernetesId, labelSelector, componentNamespace, componentName } =
-      req.query;
-    validateQueryParameters(req.query, req.params.queryId);
+    const entity = await getEntityFromRequest(req, catalogClient);
     const deployments = await queryExecutor.executeDynatraceQuery(
       req.params.queryId,
-      {
-        componentName: componentName as string,
-        componentNamespace: componentNamespace as string | undefined,
-        kubernetesId: kubernetesId as string | undefined,
-        labelFilter:
-          labelSelector && typeof labelSelector === 'string'
-            ? generateKubernetesSelectorFilter(labelSelector)
-            : undefined,
-      },
+      entity,
     );
     res.json(deployments);
   });

--- a/plugins/dql-backend/src/service/router.ts
+++ b/plugins/dql-backend/src/service/router.ts
@@ -42,8 +42,7 @@ export const createRouter = async ({
 
   router.get('/custom/:queryId', async (req, res) => {
     const result = await queryExecutor.executeCustomQuery(req.params.queryId, {
-      componentNamespace:
-        (req.query.componentNamespace as string | undefined) ?? 'default',
+      componentNamespace: req.query.componentNamespace as string,
       componentName: req.query.componentName as string,
     });
     return res.json(result);

--- a/plugins/dql-backend/src/service/standaloneServer.ts
+++ b/plugins/dql-backend/src/service/standaloneServer.ts
@@ -16,6 +16,7 @@
 import { createRouter } from './router';
 import { createServiceBuilder } from '@backstage/backend-common';
 import { ConfigReader } from '@backstage/config';
+import { PluginEnvironment } from 'backend/src/types';
 import { Server } from 'http';
 import { Logger } from 'winston';
 
@@ -33,7 +34,15 @@ export const startStandaloneServer = async (
   const router = await createRouter({
     logger,
     config: new ConfigReader({}),
-  });
+    discovery: {
+      async getBaseUrl(pluginId: string): Promise<string> {
+        return `http://localhost:${options.port}/api/${pluginId}`;
+      },
+      async getExternalBaseUrl(pluginId: string): Promise<string> {
+        return `http://localhost:${options.port}/api/${pluginId}`;
+      },
+    },
+  } as unknown as PluginEnvironment);
 
   let service = createServiceBuilder(module)
     .setPort(options.port)

--- a/plugins/dql-backend/src/utils/labelSelectorParser.test.ts
+++ b/plugins/dql-backend/src/utils/labelSelectorParser.test.ts
@@ -1,0 +1,54 @@
+/**
+ * @license
+ * Copyright 2024 Dynatrace LLC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { generateKubernetesSelectorFilter } from './labelSelectorParser';
+
+describe('label-parser', () => {
+  it('should correctly parse labels', () => {
+    // act
+    const filter = generateKubernetesSelectorFilter(
+      'label1=value1,label2=value2',
+    );
+
+    // assert
+    expect(filter).toBe(
+      '| filter workload.labels[`label1`] == "value1" AND workload.labels[`label2`] == "value2"',
+    );
+  });
+
+  it('should return empty if there are no labels', () => {
+    // act
+    const filter = generateKubernetesSelectorFilter('');
+
+    // assert
+    expect(filter).toBe('');
+  });
+
+  it('should dismiss selectors if they do not contain a key value pair', () => {
+    // act
+    const filter = generateKubernetesSelectorFilter('label1,label2=value2');
+
+    // assert
+    expect(filter).toBe('| filter workload.labels[`label2`] == "value2"');
+  });
+
+  it('should return empty string if selector is invalid', () => {
+    // act
+    const filter = generateKubernetesSelectorFilter('label1=');
+
+    // assert
+    expect(filter).toBe('');
+  });
+});

--- a/plugins/dql-backend/src/utils/labelSelectorParser.ts
+++ b/plugins/dql-backend/src/utils/labelSelectorParser.ts
@@ -1,0 +1,55 @@
+/**
+ * @license
+ * Copyright 2024 Dynatrace LLC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+interface LabelKeyValue {
+  key: string;
+  value: string;
+}
+
+function parseKubernetesSelector(labelSelector: string): LabelKeyValue[] {
+  const statements = labelSelector.split(',');
+  return statements
+    .map<LabelKeyValue | undefined>(statement => {
+      const keyValue = statement.split('=');
+      if (keyValue.length < 2) {
+        return undefined;
+      }
+      return {
+        key: keyValue[0].trim(),
+        value: keyValue[1].trim(),
+      };
+    })
+    .filter((label): label is LabelKeyValue => !!label);
+}
+
+/**
+ * Parses a kubernetes label selector to a DQL query filter
+ * @example
+ * 'backstage.io/kubernetes-label-selector': 'label1=value1,label2=value2' to "| filter workload.labels[`label1`] == value1 AND workload.labels[`label2`] == value2
+ * @param labelSelector
+ */
+export function generateKubernetesSelectorFilter(
+  labelSelector: string,
+): string {
+  const labels = parseKubernetesSelector(labelSelector);
+  if (labels.length === 0) {
+    return '';
+  }
+  const labelMap = labels
+    .map(label => `workload.labels[\`${label.key}\`] == ${label.value}`)
+    .join(' AND ');
+
+  return `| filter ${labelMap}`;
+}

--- a/plugins/dql-backend/src/utils/labelSelectorParser.ts
+++ b/plugins/dql-backend/src/utils/labelSelectorParser.ts
@@ -46,7 +46,7 @@ function parseKubernetesSelector(labelSelector: string): LabelKeyValue[] {
 /**
  * Parses a kubernetes label selector to a DQL filter
  * @example
- * 'backstage.io/kubernetes-label-selector': 'label1=value1,label2=value2' to "| filter workload.labels[`label1`] == value1 AND workload.labels[`label2`] == value2"
+ * 'backstage.io/kubernetes-label-selector': 'label1=value1,label2=value2' to "| filter workload.labels[`label1`] == "value1" AND workload.labels[`label2`] == "value2""
  * @param labelSelector
  */
 export function generateKubernetesSelectorFilter(

--- a/plugins/dql-backend/src/utils/labelSelectorParser.ts
+++ b/plugins/dql-backend/src/utils/labelSelectorParser.ts
@@ -23,12 +23,21 @@ function parseKubernetesSelector(labelSelector: string): LabelKeyValue[] {
   return statements
     .map<LabelKeyValue | undefined>(statement => {
       const keyValue = statement.split('=');
+
       if (keyValue.length < 2) {
         return undefined;
       }
+
+      const key = keyValue[0].trim();
+      const value = keyValue[1].trim();
+
+      if (!key || !value) {
+        return undefined;
+      }
+
       return {
-        key: keyValue[0].trim(),
-        value: keyValue[1].trim(),
+        key,
+        value,
       };
     })
     .filter((label): label is LabelKeyValue => !!label);
@@ -48,8 +57,8 @@ export function generateKubernetesSelectorFilter(
     return '';
   }
   const labelMap = labels
-    .map(label => `workload.labels[\`${label.key}\`] == ${label.value}`)
+    .map(label => `workload.labels[\`${label.key}\`] == "${label.value}"`)
     .join(' AND ');
 
-  return `| filter ${labelMap}`;
+  return labelMap ? `| filter ${labelMap}` : '';
 }

--- a/plugins/dql-backend/src/utils/labelSelectorParser.ts
+++ b/plugins/dql-backend/src/utils/labelSelectorParser.ts
@@ -35,9 +35,9 @@ function parseKubernetesSelector(labelSelector: string): LabelKeyValue[] {
 }
 
 /**
- * Parses a kubernetes label selector to a DQL query filter
+ * Parses a kubernetes label selector to a DQL filter
  * @example
- * 'backstage.io/kubernetes-label-selector': 'label1=value1,label2=value2' to "| filter workload.labels[`label1`] == value1 AND workload.labels[`label2`] == value2
+ * 'backstage.io/kubernetes-label-selector': 'label1=value1,label2=value2' to "| filter workload.labels[`label1`] == value1 AND workload.labels[`label2`] == value2"
  * @param labelSelector
  */
 export function generateKubernetesSelectorFilter(

--- a/plugins/dql-backend/src/utils/routeUtils.test.ts
+++ b/plugins/dql-backend/src/utils/routeUtils.test.ts
@@ -22,7 +22,7 @@ describe('routeUtils', () => {
   const namespaceFilter = '| filter Namespace == "namespace"';
 
   describe('generateComplexFilter', () => {
-    it('should return a filter for all given values', () => {
+    it('should return a filter for all given values with the exception that the label-selector overrides the kubernetes id', () => {
       // act
       const filter = generateComplexFilter(
         'kubernetesId',
@@ -31,9 +31,7 @@ describe('routeUtils', () => {
       );
 
       // assert
-      expect(filter).toBe(
-        `${kubernetesFilter}\n${labelFilter}\n${namespaceFilter}`,
-      );
+      expect(filter).toBe(`${labelFilter}\n${namespaceFilter}`);
     });
 
     it('should not return kubernetesId filter if not given', () => {
@@ -69,7 +67,7 @@ describe('routeUtils', () => {
       );
 
       // assert
-      expect(filter).toBe(`${kubernetesFilter}\n${labelFilter}`);
+      expect(filter).toBe(`${labelFilter}`);
     });
 
     it('should not return any filter if none is given', () => {
@@ -83,10 +81,19 @@ describe('routeUtils', () => {
 
   describe('validateQueryParameters', () => {
     describe('kubernetes-deployments', () => {
-      it('should fail if kubernetesId is not given', () => {
+      it('should fail if kubernetesId and label selector is not given', () => {
         expect(() =>
           validateQueryParameters({}, 'kubernetes-deployments'),
         ).toThrow();
+      });
+
+      it('should not fail if kubernetes-label-selector is given', () => {
+        expect(() =>
+          validateQueryParameters(
+            { labelSelector: 'stage=hardening' },
+            'kubernetes-deployments',
+          ),
+        ).not.toThrow();
       });
 
       it('should not fail if kubernetesId is given', () => {

--- a/plugins/dql-backend/src/utils/routeUtils.test.ts
+++ b/plugins/dql-backend/src/utils/routeUtils.test.ts
@@ -1,0 +1,81 @@
+/**
+ * @license
+ * Copyright 2024 Dynatrace LLC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { generateComplexFilter } from './routeUtils';
+
+describe('routeUtils', () => {
+  const kubernetesFilter =
+    '| filter workload.labels[`backstage.io/kubernetes-id`] == "kubernetesId"';
+  const labelFilter = '| filter workload.labels[`label1`] == "value1"';
+  const namespaceFilter = '| filter namespace.id == "namespace"';
+
+  it('should return a filter for all given values', () => {
+    // act
+    const filter = generateComplexFilter(
+      'kubernetesId',
+      'label1=value1',
+      'namespace',
+    );
+
+    // assert
+    expect(filter).toBe(
+      `${kubernetesFilter}\n${labelFilter}\n${namespaceFilter}`,
+    );
+  });
+
+  it('should not return kubernetesId filter if not given', () => {
+    // act
+    const filter = generateComplexFilter(
+      undefined,
+      'label1=value1',
+      'namespace',
+    );
+
+    // assert
+    expect(filter).toBe(`${labelFilter}\n${namespaceFilter}`);
+  });
+
+  it('should not return label filter if not given', () => {
+    // act
+    const filter = generateComplexFilter(
+      'kubernetesId',
+      undefined,
+      'namespace',
+    );
+
+    // assert
+    expect(filter).toBe(`${kubernetesFilter}\n${namespaceFilter}`);
+  });
+
+  it('should not return namespace filter if not given', () => {
+    // act
+    const filter = generateComplexFilter(
+      'kubernetesId',
+      'label1=value1',
+      undefined,
+    );
+
+    // assert
+    expect(filter).toBe(`${kubernetesFilter}\n${labelFilter}`);
+  });
+
+  it('should not return any filter if none is given', () => {
+    // act
+    const filter = generateComplexFilter(undefined, undefined, undefined);
+
+    // assert
+    expect(filter).toBe('');
+  });
+});

--- a/plugins/dql-backend/src/utils/routeUtils.test.ts
+++ b/plugins/dql-backend/src/utils/routeUtils.test.ts
@@ -13,72 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { generateComplexFilter, validateQueryParameters } from './routeUtils';
+import { validateQueryParameters } from './routeUtils';
 
 describe('routeUtils', () => {
-  const kubernetesFilter =
-    '| filter workload.labels[`backstage.io/kubernetes-id`] == "kubernetesId"';
-  const labelFilter = '| filter workload.labels[`label1`] == "value1"';
-  const namespaceFilter = '| filter Namespace == "namespace"';
-
-  describe('generateComplexFilter', () => {
-    it('should return a filter for all given values with the exception that the label-selector overrides the kubernetes id', () => {
-      // act
-      const filter = generateComplexFilter(
-        'kubernetesId',
-        'label1=value1',
-        'namespace',
-      );
-
-      // assert
-      expect(filter).toBe(`${labelFilter}\n${namespaceFilter}`);
-    });
-
-    it('should not return kubernetesId filter if not given', () => {
-      // act
-      const filter = generateComplexFilter(
-        undefined,
-        'label1=value1',
-        'namespace',
-      );
-
-      // assert
-      expect(filter).toBe(`${labelFilter}\n${namespaceFilter}`);
-    });
-
-    it('should not return label filter if not given', () => {
-      // act
-      const filter = generateComplexFilter(
-        'kubernetesId',
-        undefined,
-        'namespace',
-      );
-
-      // assert
-      expect(filter).toBe(`${kubernetesFilter}\n${namespaceFilter}`);
-    });
-
-    it('should not return namespace filter if not given', () => {
-      // act
-      const filter = generateComplexFilter(
-        'kubernetesId',
-        'label1=value1',
-        undefined,
-      );
-
-      // assert
-      expect(filter).toBe(`${labelFilter}`);
-    });
-
-    it('should not return any filter if none is given', () => {
-      // act
-      const filter = generateComplexFilter(undefined, undefined, undefined);
-
-      // assert
-      expect(filter).toBe('');
-    });
-  });
-
   describe('validateQueryParameters', () => {
     describe('kubernetes-deployments', () => {
       it('should fail if kubernetesId and label selector is not given', () => {

--- a/plugins/dql-backend/src/utils/routeUtils.test.ts
+++ b/plugins/dql-backend/src/utils/routeUtils.test.ts
@@ -19,7 +19,7 @@ describe('routeUtils', () => {
   const kubernetesFilter =
     '| filter workload.labels[`backstage.io/kubernetes-id`] == "kubernetesId"';
   const labelFilter = '| filter workload.labels[`label1`] == "value1"';
-  const namespaceFilter = '| filter namespace.id == "namespace"';
+  const namespaceFilter = '| filter Namespace == "namespace"';
 
   it('should return a filter for all given values', () => {
     // act

--- a/plugins/dql-backend/src/utils/routeUtils.ts
+++ b/plugins/dql-backend/src/utils/routeUtils.ts
@@ -13,11 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { generateKubernetesSelectorFilter } from './labelSelectorParser';
 import { ParsedQs } from 'qs';
-
-type ValueOf<T> = T[keyof T];
-type QueryValue = ValueOf<ParsedQs>;
 
 const validateKubernetesQueryParams = (queryParams: ParsedQs) => {
   const { kubernetesId, labelSelector } = queryParams;
@@ -46,25 +42,4 @@ export const validateQueryParameters = (
   queryId: string,
 ): void => {
   queryValidators[queryId]?.(queryParams);
-};
-
-export const generateComplexFilter = (
-  kubernetesId: QueryValue,
-  labelSelector: QueryValue,
-  namespace: QueryValue,
-) => {
-  const filters: string[] = [];
-  if (labelSelector && typeof labelSelector === 'string') {
-    filters.push(generateKubernetesSelectorFilter(labelSelector)); // component annotation "backstage.io/kubernetes-label-selector"
-  }
-  // only if labelSelector is not given. "Label selector takes precedence over the kubernetes-id"
-  if (kubernetesId && typeof kubernetesId === 'string' && !labelSelector) {
-    filters.push(
-      `| filter workload.labels[\`backstage.io/kubernetes-id\`] == "${kubernetesId}"`, // component annotation "backstage.io/kubernetes-id"
-    );
-  }
-  if (namespace && typeof namespace === 'string') {
-    filters.push(`| filter Namespace == "${namespace}"`); // component annotation "backstage.io/kubernetes-namespace" || component.metadata.namespace || 'default'
-  }
-  return filters.join('\n');
 };

--- a/plugins/dql-backend/src/utils/routeUtils.ts
+++ b/plugins/dql-backend/src/utils/routeUtils.ts
@@ -34,7 +34,7 @@ export const generateComplexFilter = (
     filters.push(generateKubernetesSelectorFilter(labelSelector)); // component annotation "backstage.io/kubernetes-label-selector"
   }
   if (namespace && typeof namespace === 'string') {
-    filters.push(`| filter namespace.id == "${namespace}"`); // component annotation "backstage.io/kubernetes-namespace" || component.metadata.namespace || 'default'
+    filters.push(`| filter Namespace == "${namespace}"`); // component annotation "backstage.io/kubernetes-namespace" || component.metadata.namespace || 'default'
   }
   return filters.join('\n');
 };

--- a/plugins/dql-backend/src/utils/routeUtils.ts
+++ b/plugins/dql-backend/src/utils/routeUtils.ts
@@ -19,6 +19,33 @@ import { ParsedQs } from 'qs';
 type ValueOf<T> = T[keyof T];
 type QueryValue = ValueOf<ParsedQs>;
 
+const validateKubernetesQueryParams = (queryParams: ParsedQs) => {
+  const { kubernetesId } = queryParams;
+  if (!kubernetesId) {
+    throw new Error('Missing query parameter "kubernetesId"');
+  }
+};
+
+const queryValidators: Record<
+  string,
+  (queryParams: ParsedQs) => void | undefined
+> = {
+  'kubernetes-deployments': validateKubernetesQueryParams,
+};
+
+/**
+ * Validates if all required query params are set for a specific query.
+ * Throws an error if some are missing
+ * @param queryParams
+ * @param queryId
+ */
+export const validateQueryParameters = (
+  queryParams: ParsedQs,
+  queryId: string,
+): void => {
+  queryValidators[queryId]?.(queryParams);
+};
+
 export const generateComplexFilter = (
   kubernetesId: QueryValue,
   labelSelector: QueryValue,

--- a/plugins/dql-backend/src/utils/routeUtils.ts
+++ b/plugins/dql-backend/src/utils/routeUtils.ts
@@ -1,0 +1,40 @@
+/**
+ * @license
+ * Copyright 2024 Dynatrace LLC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { generateKubernetesSelectorFilter } from './labelSelectorParser';
+import { ParsedQs } from 'qs';
+
+type ValueOf<T> = T[keyof T];
+type QueryValue = ValueOf<ParsedQs>;
+
+export const generateComplexFilter = (
+  kubernetesId: QueryValue,
+  labelSelector: QueryValue,
+  componentNamespace: QueryValue,
+) => {
+  const filters: string[] = [];
+  if (kubernetesId && typeof kubernetesId === 'string') {
+    filters.push(
+      `| filter workload.labels[\`backstage.io/kubernetes-id\`] == "${kubernetesId}"`, // component annotation backstage.io/kubernetes-id
+    );
+  }
+  if (labelSelector && typeof labelSelector === 'string') {
+    filters.push(generateKubernetesSelectorFilter(labelSelector));
+  }
+  if (componentNamespace && typeof componentNamespace === 'string') {
+    filters.push(`| filter namespace.id == "${componentNamespace}"`); // component annotation backstage.io/kubernetes-namespace || component.metadata.namespace || 'default'
+  }
+  return filters.join('\n');
+};

--- a/plugins/dql-backend/src/utils/routeUtils.ts
+++ b/plugins/dql-backend/src/utils/routeUtils.ts
@@ -27,14 +27,14 @@ export const generateComplexFilter = (
   const filters: string[] = [];
   if (kubernetesId && typeof kubernetesId === 'string') {
     filters.push(
-      `| filter workload.labels[\`backstage.io/kubernetes-id\`] == "${kubernetesId}"`, // component annotation backstage.io/kubernetes-id
+      `| filter workload.labels[\`backstage.io/kubernetes-id\`] == "${kubernetesId}"`, // component annotation "backstage.io/kubernetes-id"
     );
   }
   if (labelSelector && typeof labelSelector === 'string') {
-    filters.push(generateKubernetesSelectorFilter(labelSelector));
+    filters.push(generateKubernetesSelectorFilter(labelSelector)); // component annotation "backstage.io/kubernetes-label-selector"
   }
   if (componentNamespace && typeof componentNamespace === 'string') {
-    filters.push(`| filter namespace.id == "${componentNamespace}"`); // component annotation backstage.io/kubernetes-namespace || component.metadata.namespace || 'default'
+    filters.push(`| filter namespace.id == "${componentNamespace}"`); // component annotation "backstage.io/kubernetes-namespace" || component.metadata.namespace || 'default'
   }
   return filters.join('\n');
 };

--- a/plugins/dql-backend/src/utils/routeUtils.ts
+++ b/plugins/dql-backend/src/utils/routeUtils.ts
@@ -22,7 +22,7 @@ type QueryValue = ValueOf<ParsedQs>;
 export const generateComplexFilter = (
   kubernetesId: QueryValue,
   labelSelector: QueryValue,
-  componentNamespace: QueryValue,
+  namespace: QueryValue,
 ) => {
   const filters: string[] = [];
   if (kubernetesId && typeof kubernetesId === 'string') {
@@ -33,8 +33,8 @@ export const generateComplexFilter = (
   if (labelSelector && typeof labelSelector === 'string') {
     filters.push(generateKubernetesSelectorFilter(labelSelector)); // component annotation "backstage.io/kubernetes-label-selector"
   }
-  if (componentNamespace && typeof componentNamespace === 'string') {
-    filters.push(`| filter namespace.id == "${componentNamespace}"`); // component annotation "backstage.io/kubernetes-namespace" || component.metadata.namespace || 'default'
+  if (namespace && typeof namespace === 'string') {
+    filters.push(`| filter namespace.id == "${namespace}"`); // component annotation "backstage.io/kubernetes-namespace" || component.metadata.namespace || 'default'
   }
   return filters.join('\n');
 };

--- a/plugins/dql/src/api/DqlQueryApiClient.test.ts
+++ b/plugins/dql/src/api/DqlQueryApiClient.test.ts
@@ -45,6 +45,8 @@ const mockDiscoveryApiUrl = (url: string): DiscoveryApi => {
   return discoveryApi;
 };
 
+const mockedEntityRef = 'component:default/example';
+
 describe('DQLQueryApiClient', () => {
   beforeAll(() => server.listen());
   beforeEach(() => jest.resetAllMocks());
@@ -56,12 +58,7 @@ describe('DQLQueryApiClient', () => {
     const discoveryApi = mockDiscoveryApiUrl('https://discovery-api.com');
     const client = new DqlQueryApiClient({ discoveryApi });
 
-    await client.getData(
-      'namespace',
-      'queryName',
-      'componentName',
-      'componentNamespace',
-    );
+    await client.getData('namespace', 'queryName', mockedEntityRef);
 
     expect(discoveryApi.getBaseUrl).toHaveBeenCalledWith('dynatrace-dql');
   });
@@ -70,10 +67,8 @@ describe('DQLQueryApiClient', () => {
     const discoveryApiUrl = 'https://discovery-api.com';
     const queryNamespace = 'namespace';
     const queryName = 'query';
-    const componentName = 'componentName^';
-    const componentNamespace = 'componentNamespace^';
     const url = `${discoveryApiUrl}/${queryNamespace}/${queryName}`;
-    const queryParams = `componentName=componentName%5E&componentNamespace=componentNamespace%5E`;
+    const queryParams = `entityRef=component%3Adefault%2Fexample`;
     mockFetchResponse([], url, queryParams);
     const discoveryApi = mockDiscoveryApiUrl(discoveryApiUrl);
     const client = new DqlQueryApiClient({ discoveryApi });
@@ -81,8 +76,7 @@ describe('DQLQueryApiClient', () => {
     const result = await client.getData(
       queryNamespace,
       queryName,
-      componentName,
-      componentNamespace,
+      mockedEntityRef,
     );
 
     expect(result).toEqual([]);
@@ -97,8 +91,7 @@ describe('DQLQueryApiClient', () => {
     const result = await client.getData(
       'queryNamespace',
       'queryName',
-      'componentName',
-      'componentNamespace',
+      mockedEntityRef,
     );
 
     expect(result).toEqual(response);
@@ -115,12 +108,7 @@ describe('DQLQueryApiClient', () => {
     const client = new DqlQueryApiClient({ discoveryApi });
 
     await expect(
-      client.getData(
-        'queryNamespace',
-        'queryName',
-        'componentName',
-        'componentNamespace',
-      ),
+      client.getData('queryNamespace', 'queryName', mockedEntityRef),
     ).rejects.toThrow('invalid json');
   });
 
@@ -130,12 +118,7 @@ describe('DQLQueryApiClient', () => {
     const client = new DqlQueryApiClient({ discoveryApi });
 
     await expect(
-      client.getData(
-        'queryNamespace',
-        'queryName',
-        'componentName',
-        'componentNamespace',
-      ),
+      client.getData('queryNamespace', 'queryName', mockedEntityRef),
     ).rejects.toThrow();
   });
 
@@ -152,12 +135,7 @@ describe('DQLQueryApiClient', () => {
     const client = new DqlQueryApiClient({ discoveryApi });
 
     await expect(
-      client.getData(
-        'queryNamespace',
-        'queryName',
-        'componentName',
-        'componentNamespace',
-      ),
+      client.getData('queryNamespace', 'queryName', mockedEntityRef),
     ).rejects.toThrow(`Query queryNamespace/queryName does not exist.`);
   });
 
@@ -174,12 +152,7 @@ describe('DQLQueryApiClient', () => {
     const client = new DqlQueryApiClient({ discoveryApi });
 
     await expect(
-      client.getData(
-        'queryNamespace',
-        'queryName',
-        'componentName',
-        'componentNamespace',
-      ),
+      client.getData('queryNamespace', 'queryName', mockedEntityRef),
     ).rejects.toThrow('Request failed with 500 Error');
   });
 });

--- a/plugins/dql/src/api/DqlQueryApiClient.ts
+++ b/plugins/dql/src/api/DqlQueryApiClient.ts
@@ -33,6 +33,7 @@ export class DqlQueryApiClient implements DqlQueryApi {
     queryName: string,
     componentName: string,
     componentNamespace: string,
+    namespaceSelector?: string,
     kubernetesId?: string,
     labelSelector?: string,
   ): Promise<TabularData> {
@@ -40,6 +41,7 @@ export class DqlQueryApiClient implements DqlQueryApi {
     const searchParams = new URLSearchParams({
       componentName,
       componentNamespace,
+      ...(namespaceSelector && { namespaceSelector }),
       ...(labelSelector && { labelSelector }),
       ...(kubernetesId && { kubernetesId }),
     });

--- a/plugins/dql/src/api/DqlQueryApiClient.ts
+++ b/plugins/dql/src/api/DqlQueryApiClient.ts
@@ -33,7 +33,6 @@ export class DqlQueryApiClient implements DqlQueryApi {
     queryName: string,
     componentName: string,
     componentNamespace: string,
-    namespaceSelector?: string,
     kubernetesId?: string,
     labelSelector?: string,
   ): Promise<TabularData> {
@@ -41,7 +40,6 @@ export class DqlQueryApiClient implements DqlQueryApi {
     const searchParams = new URLSearchParams({
       componentName,
       componentNamespace,
-      ...(namespaceSelector && { namespaceSelector }),
       ...(labelSelector && { labelSelector }),
       ...(kubernetesId && { kubernetesId }),
     });

--- a/plugins/dql/src/api/DqlQueryApiClient.ts
+++ b/plugins/dql/src/api/DqlQueryApiClient.ts
@@ -33,11 +33,17 @@ export class DqlQueryApiClient implements DqlQueryApi {
     queryName: string,
     componentName: string,
     componentNamespace: string,
+    kubernetesId?: string,
+    labelSelector?: string,
   ): Promise<TabularData> {
     const baseUrl = await this.discoveryApi.getBaseUrl('dynatrace-dql');
-    const encodedComponentName = encodeURIComponent(componentName);
-    const encodedComponentNamespace = encodeURIComponent(componentNamespace);
-    const url = `${baseUrl}/${queryNamespace}/${queryName}?componentName=${encodedComponentName}&componentNamespace=${encodedComponentNamespace}`;
+    const searchParams = new URLSearchParams({
+      componentName,
+      componentNamespace,
+      ...(labelSelector && { labelSelector }),
+      ...(kubernetesId && { kubernetesId }),
+    });
+    const url = `${baseUrl}/${queryNamespace}/${queryName}?${searchParams}`;
     const response = await fetch(url, {
       method: 'GET',
     });

--- a/plugins/dql/src/api/DqlQueryApiClient.ts
+++ b/plugins/dql/src/api/DqlQueryApiClient.ts
@@ -32,14 +32,14 @@ export class DqlQueryApiClient implements DqlQueryApi {
     queryNamespace: string,
     queryName: string,
     componentName: string,
-    componentNamespace: string,
+    componentNamespace?: string,
     kubernetesId?: string,
     labelSelector?: string,
   ): Promise<TabularData> {
     const baseUrl = await this.discoveryApi.getBaseUrl('dynatrace-dql');
     const searchParams = new URLSearchParams({
       componentName,
-      componentNamespace,
+      ...(componentNamespace && { componentNamespace }),
       ...(labelSelector && { labelSelector }),
       ...(kubernetesId && { kubernetesId }),
     });

--- a/plugins/dql/src/api/DqlQueryApiClient.ts
+++ b/plugins/dql/src/api/DqlQueryApiClient.ts
@@ -31,18 +31,10 @@ export class DqlQueryApiClient implements DqlQueryApi {
   async getData(
     queryNamespace: string,
     queryName: string,
-    componentName: string,
-    componentNamespace?: string,
-    kubernetesId?: string,
-    labelSelector?: string,
+    entityRef: string,
   ): Promise<TabularData> {
     const baseUrl = await this.discoveryApi.getBaseUrl('dynatrace-dql');
-    const searchParams = new URLSearchParams({
-      componentName,
-      ...(componentNamespace && { componentNamespace }),
-      ...(labelSelector && { labelSelector }),
-      ...(kubernetesId && { kubernetesId }),
-    });
+    const searchParams = new URLSearchParams({ entityRef });
     const url = `${baseUrl}/${queryNamespace}/${queryName}?${searchParams}`;
     const response = await fetch(url, {
       method: 'GET',

--- a/plugins/dql/src/api/types.ts
+++ b/plugins/dql/src/api/types.ts
@@ -21,6 +21,7 @@ export type DqlQueryApi = {
     queryName: string,
     componentName: string,
     componentNamespace: string,
+    namespaceSelector?: string,
     kubernetesId?: string,
     labelSelector?: string,
   ): Promise<TabularData>;

--- a/plugins/dql/src/api/types.ts
+++ b/plugins/dql/src/api/types.ts
@@ -21,5 +21,7 @@ export type DqlQueryApi = {
     queryName: string,
     componentName: string,
     componentNamespace: string,
+    kubernetesId?: string,
+    labelSelector?: string,
   ): Promise<TabularData>;
 };

--- a/plugins/dql/src/api/types.ts
+++ b/plugins/dql/src/api/types.ts
@@ -21,7 +21,6 @@ export type DqlQueryApi = {
     queryName: string,
     componentName: string,
     componentNamespace: string,
-    namespaceSelector?: string,
     kubernetesId?: string,
     labelSelector?: string,
   ): Promise<TabularData>;

--- a/plugins/dql/src/api/types.ts
+++ b/plugins/dql/src/api/types.ts
@@ -19,9 +19,6 @@ export type DqlQueryApi = {
   getData(
     queryNamespace: string,
     queryName: string,
-    componentName: string,
-    componentNamespace?: string,
-    kubernetesId?: string,
-    labelSelector?: string,
+    entityRef: string,
   ): Promise<TabularData>;
 };

--- a/plugins/dql/src/api/types.ts
+++ b/plugins/dql/src/api/types.ts
@@ -20,7 +20,7 @@ export type DqlQueryApi = {
     queryNamespace: string,
     queryName: string,
     componentName: string,
-    componentNamespace: string,
+    componentNamespace?: string,
     kubernetesId?: string,
     labelSelector?: string,
   ): Promise<TabularData>;

--- a/plugins/dql/src/components/DqlEmptyState.test.tsx
+++ b/plugins/dql/src/components/DqlEmptyState.test.tsx
@@ -19,19 +19,16 @@ import React from 'react';
 
 const prepareComponent = ({
   componentName = 'example',
-  componentNamespace = 'default',
   queryName = 'query',
   queryNamespace = 'dynatrace',
 }: {
   componentName?: string;
-  componentNamespace?: string;
   queryName?: string;
   queryNamespace?: string;
 }) => {
   return render(
     <DqlEmptyState
       componentName={componentName}
-      componentNamespace={componentNamespace}
       queryName={queryName}
       queryNamespace={queryNamespace}
     />,
@@ -41,17 +38,15 @@ const prepareComponent = ({
 describe('DqlEmptyState', () => {
   it('should include the component and query references in the explanation', () => {
     const componentName = 'example';
-    const componentNamespace = 'default';
     const queryName = 'query-id-1';
     const queryNamespace = 'dynatrace';
     const rendered = prepareComponent({
       componentName,
-      componentNamespace,
       queryName,
       queryNamespace,
     });
 
-    expect(rendered.getByText(/default.example/)).toBeInTheDocument();
+    expect(rendered.getByText(/example/)).toBeInTheDocument();
     expect(rendered.getByText(/dynatrace.query-id-1/)).toBeInTheDocument();
   });
 });

--- a/plugins/dql/src/components/DqlEmptyState.tsx
+++ b/plugins/dql/src/components/DqlEmptyState.tsx
@@ -19,14 +19,13 @@ import React from 'react';
 
 export const DqlEmptyState = ({
   componentName,
-  componentNamespace,
   queryName,
   queryNamespace,
 }: EmptyStateProps) => {
   const message = `# We turned up empty
 
   Query \`${queryNamespace}.${queryName}\` did not return any data for
-  component \`${componentNamespace}.${componentName}\`.
+  component \`${componentName}\`.
 
   If you recently added the component, it may take a few minutes for
   Dynatrace to start reporting data. If the component has been running

--- a/plugins/dql/src/components/DqlQuery.tsx
+++ b/plugins/dql/src/components/DqlQuery.tsx
@@ -46,6 +46,7 @@ const dqlQueryPropsSchema = z.object({
 export type DqlQueryProps = {
   emptyState?: React.ComponentType<EmptyStateProps>;
   pageSize?: number;
+  isKubernetes?: boolean;
 } & z.infer<typeof dqlQueryPropsSchema>;
 
 /**
@@ -65,6 +66,7 @@ export const DqlQuery = (props: DqlQueryProps) => {
         queryName={queryName}
         EmptyState={props.emptyState}
         pageSize={props.pageSize}
+        isKubernetes={props.isKubernetes}
       />
     );
   } catch (e) {

--- a/plugins/dql/src/components/DqlQuery.tsx
+++ b/plugins/dql/src/components/DqlQuery.tsx
@@ -46,7 +46,6 @@ const dqlQueryPropsSchema = z.object({
 export type DqlQueryProps = {
   emptyState?: React.ComponentType<EmptyStateProps>;
   pageSize?: number;
-  isKubernetes?: boolean;
 } & z.infer<typeof dqlQueryPropsSchema>;
 
 /**
@@ -66,7 +65,6 @@ export const DqlQuery = (props: DqlQueryProps) => {
         queryName={queryName}
         EmptyState={props.emptyState}
         pageSize={props.pageSize}
-        isKubernetes={props.isKubernetes}
       />
     );
   } catch (e) {

--- a/plugins/dql/src/components/InternalDqlQuery.test.tsx
+++ b/plugins/dql/src/components/InternalDqlQuery.test.tsx
@@ -138,6 +138,7 @@ describe('DqlQuery', () => {
       'namespace',
       undefined,
       undefined,
+      undefined,
     );
   });
 
@@ -153,13 +154,16 @@ describe('DqlQuery', () => {
       'default',
       undefined,
       undefined,
+      undefined,
     );
   });
 
-  it('should fill in "backstage.io/kubernetes-namespace" annotation to namespace', async () => {
+  it('should fill in annotations', async () => {
     const queryApi = mockDqlQueryApi();
     const entity = mockEntity('example', undefined, {
       'backstage.io/kubernetes-namespace': 'annotationNamespace',
+      'backstage.io/kubernetes-id': 'kubernetesId',
+      'backstage.io/kubernetes-label-selector': 'label=selector',
     });
     await prepareComponent({ entity, queryApi });
 
@@ -167,9 +171,10 @@ describe('DqlQuery', () => {
       expect.anything(),
       expect.anything(),
       'example',
+      'default',
       'annotationNamespace',
-      undefined,
-      undefined,
+      'kubernetesId',
+      'label=selector',
     );
   });
 

--- a/plugins/dql/src/components/InternalDqlQuery.test.tsx
+++ b/plugins/dql/src/components/InternalDqlQuery.test.tsx
@@ -41,6 +41,7 @@ jest.mock('@backstage/core-components', () => ({
 const mockEntity = (
   name: string = 'example',
   annotations?: Record<string, string>,
+  namespace?: string,
 ): Entity => {
   return {
     apiVersion: 'backstage.io/v1alpha1',
@@ -49,6 +50,7 @@ const mockEntity = (
       name,
       description: 'backstage.io/example',
       annotations,
+      namespace,
     },
     spec: {
       lifecycle: 'production',
@@ -124,9 +126,9 @@ describe('DqlQuery', () => {
     );
   });
 
-  it('should fill in empty namespaces with default', async () => {
+  it('should fill in metadata namespace', async () => {
     const queryApi = mockDqlQueryApi();
-    const entity = mockEntity('example');
+    const entity = mockEntity('example', undefined, 'metadata-namespace');
     await prepareComponent({ entity, queryApi });
 
     expect(queryApi.getData).toHaveBeenCalledWith<
@@ -135,7 +137,7 @@ describe('DqlQuery', () => {
       expect.anything(),
       expect.anything(),
       'example',
-      'default',
+      'metadata-namespace',
       undefined,
       undefined,
     );
@@ -183,7 +185,6 @@ describe('DqlQuery', () => {
 
   it('should render an default empty state if no data is returned', async () => {
     const componentName = 'example';
-    const componentNamespace = 'default';
     const queryName = 'query-id-1';
     const queryNamespace = 'dynatrace';
 
@@ -193,12 +194,11 @@ describe('DqlQuery', () => {
 
     expect(TabularDataTable).not.toHaveBeenCalled();
     expect(ResponseErrorPanel).not.toHaveBeenCalled();
-    expect(DqlEmptyState).toHaveBeenCalledWith(
-      expect.objectContaining({
+    expect(DqlEmptyState).toHaveBeenCalledWith<[EmptyStateProps, unknown]>(
+      expect.objectContaining<Partial<EmptyStateProps>>({
         queryNamespace,
         queryName,
         componentName,
-        componentNamespace,
       }),
       expect.anything(),
     );
@@ -206,7 +206,6 @@ describe('DqlQuery', () => {
 
   it('should render a custom empty state if no data is returned', async () => {
     const componentName = 'example';
-    const componentNamespace = 'default';
     const queryName = 'query-id-1';
     const queryNamespace = 'dynatrace';
 
@@ -224,12 +223,11 @@ describe('DqlQuery', () => {
     expect(TabularDataTable).not.toHaveBeenCalled();
     expect(ResponseErrorPanel).not.toHaveBeenCalled();
     expect(DqlEmptyState).not.toHaveBeenCalled();
-    expect(EmptyState).toHaveBeenCalledWith(
-      expect.objectContaining({
+    expect(EmptyState).toHaveBeenCalledWith<[EmptyStateProps, unknown]>(
+      expect.objectContaining<Partial<EmptyStateProps>>({
         queryNamespace,
         queryName,
         componentName,
-        componentNamespace,
       }),
       expect.anything(),
     );

--- a/plugins/dql/src/components/InternalDqlQuery.test.tsx
+++ b/plugins/dql/src/components/InternalDqlQuery.test.tsx
@@ -40,7 +40,6 @@ jest.mock('@backstage/core-components', () => ({
 
 const mockEntity = (
   name: string = 'example',
-  namespace: string | undefined = undefined,
   annotations?: Record<string, string>,
 ): Entity => {
   return {
@@ -49,7 +48,6 @@ const mockEntity = (
     metadata: {
       name,
       description: 'backstage.io/example',
-      namespace,
       annotations,
     },
     spec: {
@@ -126,33 +124,18 @@ describe('DqlQuery', () => {
     );
   });
 
-  it('should call the api with the component and namespace', async () => {
-    const queryApi = mockDqlQueryApi();
-    const entity = mockEntity('component', 'namespace');
-    await prepareComponent({ entity, queryApi });
-
-    expect(queryApi.getData).toHaveBeenCalledWith(
-      expect.anything(),
-      expect.anything(),
-      'component',
-      'namespace',
-      undefined,
-      undefined,
-      undefined,
-    );
-  });
-
   it('should fill in empty namespaces with default', async () => {
     const queryApi = mockDqlQueryApi();
-    const entity = mockEntity('example', undefined);
+    const entity = mockEntity('example');
     await prepareComponent({ entity, queryApi });
 
-    expect(queryApi.getData).toHaveBeenCalledWith(
+    expect(queryApi.getData).toHaveBeenCalledWith<
+      Parameters<DqlQueryApi['getData']>
+    >(
       expect.anything(),
       expect.anything(),
       'example',
       'default',
-      undefined,
       undefined,
       undefined,
     );
@@ -160,18 +143,19 @@ describe('DqlQuery', () => {
 
   it('should fill in annotations', async () => {
     const queryApi = mockDqlQueryApi();
-    const entity = mockEntity('example', undefined, {
+    const entity = mockEntity('example', {
       'backstage.io/kubernetes-namespace': 'annotationNamespace',
       'backstage.io/kubernetes-id': 'kubernetesId',
       'backstage.io/kubernetes-label-selector': 'label=selector',
     });
     await prepareComponent({ entity, queryApi });
 
-    expect(queryApi.getData).toHaveBeenCalledWith(
+    expect(queryApi.getData).toHaveBeenCalledWith<
+      Parameters<DqlQueryApi['getData']>
+    >(
       expect.anything(),
       expect.anything(),
       'example',
-      'default',
       'annotationNamespace',
       'kubernetesId',
       'label=selector',
@@ -204,7 +188,7 @@ describe('DqlQuery', () => {
     const queryNamespace = 'dynatrace';
 
     const queryApi = mockDqlQueryApi();
-    const entity = mockEntity(componentName, componentNamespace);
+    const entity = mockEntity(componentName);
     await prepareComponent({ entity, queryApi, queryName, queryNamespace });
 
     expect(TabularDataTable).not.toHaveBeenCalled();
@@ -227,7 +211,7 @@ describe('DqlQuery', () => {
     const queryNamespace = 'dynatrace';
 
     const queryApi = mockDqlQueryApi();
-    const entity = mockEntity(componentName, componentNamespace);
+    const entity = mockEntity(componentName);
     const EmptyState = jest.fn(() => null);
     await prepareComponent({
       entity,

--- a/plugins/dql/src/components/InternalDqlQuery.test.tsx
+++ b/plugins/dql/src/components/InternalDqlQuery.test.tsx
@@ -59,7 +59,7 @@ const mockEntity = (
     },
   };
 };
-
+const mockedEntityRef = 'component:default/example';
 const mockDqlQueryApi = (data: TabularData = []) => {
   return {
     getData: jest.fn().mockResolvedValue(data),
@@ -73,7 +73,6 @@ type PrepareComponentProps = {
   queryNamespace?: string;
   queryName?: string;
   EmptyState?: React.ComponentType<EmptyStateProps>;
-  isKubernetes?: boolean;
 };
 
 const prepareComponent = async ({
@@ -83,7 +82,6 @@ const prepareComponent = async ({
   queryNamespace = 'dynatrace',
   queryName = 'query-id-1',
   EmptyState,
-  isKubernetes,
 }: PrepareComponentProps = {}) => {
   return await renderInTestApp(
     <EntityProvider entity={entity}>
@@ -93,7 +91,6 @@ const prepareComponent = async ({
           queryNamespace={queryNamespace}
           queryName={queryName}
           EmptyState={EmptyState}
-          isKubernetes={isKubernetes}
         />
       </TestApiProvider>
     </EntityProvider>,
@@ -129,79 +126,14 @@ describe('DqlQuery', () => {
     );
   });
 
-  it('should fill in metadata namespace', async () => {
-    const queryApi = mockDqlQueryApi();
-    const entity = mockEntity('example', undefined, 'metadata-namespace');
-    await prepareComponent({ entity, queryApi });
-
-    expect(queryApi.getData).toHaveBeenCalledWith<
-      Parameters<DqlQueryApi['getData']>
-    >(
-      expect.anything(),
-      expect.anything(),
-      'example',
-      'metadata-namespace',
-      undefined,
-      undefined,
-    );
-  });
-
-  it('should fill in default namespace if it is not a kubernetes query', async () => {
+  it('should fill in entity ref', async () => {
     const queryApi = mockDqlQueryApi();
     const entity = mockEntity('example', undefined);
     await prepareComponent({ entity, queryApi });
 
     expect(queryApi.getData).toHaveBeenCalledWith<
       Parameters<DqlQueryApi['getData']>
-    >(
-      expect.anything(),
-      expect.anything(),
-      'example',
-      'default',
-      undefined,
-      undefined,
-    );
-  });
-
-  it('should fill in annotations with correct namespace if it is a kubernetes query', async () => {
-    const queryApi = mockDqlQueryApi();
-    const entity = mockEntity('example', {
-      'backstage.io/kubernetes-namespace': 'annotationNamespace',
-      'backstage.io/kubernetes-id': 'kubernetesId',
-      'backstage.io/kubernetes-label-selector': 'label=selector',
-    });
-    await prepareComponent({ entity, queryApi, isKubernetes: true });
-
-    expect(queryApi.getData).toHaveBeenCalledWith<
-      Parameters<DqlQueryApi['getData']>
-    >(
-      expect.anything(),
-      expect.anything(),
-      'example',
-      'annotationNamespace',
-      'kubernetesId',
-      'label=selector',
-    );
-  });
-
-  it('should fill in annotations without namespace if it is a kubernetes query', async () => {
-    const queryApi = mockDqlQueryApi();
-    const entity = mockEntity('example', {
-      'backstage.io/kubernetes-id': 'kubernetesId',
-      'backstage.io/kubernetes-label-selector': 'label=selector',
-    });
-    await prepareComponent({ entity, queryApi, isKubernetes: true });
-
-    expect(queryApi.getData).toHaveBeenCalledWith<
-      Parameters<DqlQueryApi['getData']>
-    >(
-      expect.anything(),
-      expect.anything(),
-      'example',
-      undefined,
-      'kubernetesId',
-      'label=selector',
-    );
+    >(expect.anything(), expect.anything(), mockedEntityRef);
   });
 
   it('should render an error panel in case of errors', async () => {

--- a/plugins/dql/src/components/InternalDqlQuery.test.tsx
+++ b/plugins/dql/src/components/InternalDqlQuery.test.tsx
@@ -41,6 +41,7 @@ jest.mock('@backstage/core-components', () => ({
 const mockEntity = (
   name: string = 'example',
   namespace: string | undefined = undefined,
+  annotations?: Record<string, string>,
 ): Entity => {
   return {
     apiVersion: 'backstage.io/v1alpha1',
@@ -49,6 +50,7 @@ const mockEntity = (
       name,
       description: 'backstage.io/example',
       namespace,
+      annotations,
     },
     spec: {
       lifecycle: 'production',
@@ -134,6 +136,8 @@ describe('DqlQuery', () => {
       expect.anything(),
       'component',
       'namespace',
+      undefined,
+      undefined,
     );
   });
 
@@ -147,6 +151,25 @@ describe('DqlQuery', () => {
       expect.anything(),
       'example',
       'default',
+      undefined,
+      undefined,
+    );
+  });
+
+  it('should fill in "backstage.io/kubernetes-namespace" annotation to namespace', async () => {
+    const queryApi = mockDqlQueryApi();
+    const entity = mockEntity('example', undefined, {
+      'backstage.io/kubernetes-namespace': 'annotationNamespace',
+    });
+    await prepareComponent({ entity, queryApi });
+
+    expect(queryApi.getData).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      'example',
+      'annotationNamespace',
+      undefined,
+      undefined,
     );
   });
 

--- a/plugins/dql/src/components/InternalDqlQuery.tsx
+++ b/plugins/dql/src/components/InternalDqlQuery.tsx
@@ -38,7 +38,9 @@ export const InternalDqlQuery = ({
 }: InternalDqlQueryProps) => {
   const { entity } = useEntity();
   const componentName = entity.metadata.name;
-  const componentNamespace = entity.metadata.namespace ?? 'default';
+  const componentNamespace =
+    entity.metadata.annotations?.['backstage.io/kubernetes-namespace'] ??
+    'default';
   const { error, loading, value } = useDqlQuery(
     queryNamespace,
     queryName,

--- a/plugins/dql/src/components/InternalDqlQuery.tsx
+++ b/plugins/dql/src/components/InternalDqlQuery.tsx
@@ -38,12 +38,16 @@ export const InternalDqlQuery = ({
 }: InternalDqlQueryProps) => {
   const { entity } = useEntity();
   const componentName = entity.metadata.name;
-  const componentNamespace = entity.metadata.namespace ?? 'default';
+  const componentNamespace =
+    entity.metadata.annotations?.['backstage.io/kubernetes-namespace'] ??
+    entity.metadata.namespace ??
+    'default';
   const { error, loading, value } = useDqlQuery(
     queryNamespace,
     queryName,
     componentName,
     componentNamespace,
+    entity.metadata.annotations,
   );
 
   if (loading) {

--- a/plugins/dql/src/components/InternalDqlQuery.tsx
+++ b/plugins/dql/src/components/InternalDqlQuery.tsx
@@ -27,6 +27,7 @@ export type InternalDqlQueryProps = {
   queryName: string;
   EmptyState?: React.ComponentType<EmptyStateProps>;
   pageSize?: number;
+  isKubernetes?: boolean;
 };
 
 export const InternalDqlQuery = ({
@@ -35,12 +36,15 @@ export const InternalDqlQuery = ({
   queryName,
   EmptyState = DqlEmptyState,
   pageSize,
+  isKubernetes,
 }: InternalDqlQueryProps) => {
   const { entity } = useEntity();
   const componentName = entity.metadata.name;
-  const componentNamespace =
-    entity.metadata.annotations?.['backstage.io/kubernetes-namespace'] ||
-    entity.metadata.namespace; // either kubernetes annotation or metadata (kubernetes query vs rest)
+  // Observation: if metadata->namespace is not defined in the catalog, entity.metadata.namespace already sets a fallback value "default"
+  // either kubernetes annotation or metadata (kubernetes query vs rest)
+  const componentNamespace = isKubernetes
+    ? entity.metadata.annotations?.['backstage.io/kubernetes-namespace']
+    : entity.metadata.namespace ?? 'default';
   const { error, loading, value } = useDqlQuery(
     queryNamespace,
     queryName,

--- a/plugins/dql/src/components/InternalDqlQuery.tsx
+++ b/plugins/dql/src/components/InternalDqlQuery.tsx
@@ -17,6 +17,7 @@ import { useDqlQuery } from '../hooks';
 import { DqlEmptyState } from './DqlEmptyState';
 import { TabularDataTable } from './TabularDataTable';
 import { EmptyStateProps } from './types';
+import { stringifyEntityRef } from '@backstage/catalog-model';
 import { Progress, ResponseErrorPanel } from '@backstage/core-components';
 import { useEntity } from '@backstage/plugin-catalog-react';
 import React from 'react';
@@ -27,7 +28,6 @@ export type InternalDqlQueryProps = {
   queryName: string;
   EmptyState?: React.ComponentType<EmptyStateProps>;
   pageSize?: number;
-  isKubernetes?: boolean;
 };
 
 export const InternalDqlQuery = ({
@@ -36,21 +36,13 @@ export const InternalDqlQuery = ({
   queryName,
   EmptyState = DqlEmptyState,
   pageSize,
-  isKubernetes,
 }: InternalDqlQueryProps) => {
   const { entity } = useEntity();
   const componentName = entity.metadata.name;
-  // Observation: if metadata->namespace is not defined in the catalog, entity.metadata.namespace already sets a fallback value "default"
-  // either kubernetes annotation or metadata (kubernetes query vs rest)
-  const componentNamespace = isKubernetes
-    ? entity.metadata.annotations?.['backstage.io/kubernetes-namespace']
-    : entity.metadata.namespace ?? 'default';
   const { error, loading, value } = useDqlQuery(
     queryNamespace,
     queryName,
-    componentName,
-    componentNamespace,
-    entity.metadata.annotations,
+    stringifyEntityRef(entity),
   );
 
   if (loading) {

--- a/plugins/dql/src/components/InternalDqlQuery.tsx
+++ b/plugins/dql/src/components/InternalDqlQuery.tsx
@@ -39,8 +39,8 @@ export const InternalDqlQuery = ({
   const { entity } = useEntity();
   const componentName = entity.metadata.name;
   const componentNamespace =
-    entity.metadata.annotations?.['backstage.io/kubernetes-namespace'] ??
-    'default';
+    entity.metadata.annotations?.['backstage.io/kubernetes-namespace'] ||
+    entity.metadata.namespace; // either kubernetes annotation or metadata (kubernetes query vs rest)
   const { error, loading, value } = useDqlQuery(
     queryNamespace,
     queryName,
@@ -59,7 +59,6 @@ export const InternalDqlQuery = ({
     return (
       <EmptyState
         componentName={componentName}
-        componentNamespace={componentNamespace}
         queryName={queryName}
         queryNamespace={queryNamespace}
       />

--- a/plugins/dql/src/components/InternalDqlQuery.tsx
+++ b/plugins/dql/src/components/InternalDqlQuery.tsx
@@ -38,10 +38,7 @@ export const InternalDqlQuery = ({
 }: InternalDqlQueryProps) => {
   const { entity } = useEntity();
   const componentName = entity.metadata.name;
-  const componentNamespace =
-    entity.metadata.annotations?.['backstage.io/kubernetes-namespace'] ??
-    entity.metadata.namespace ??
-    'default';
+  const componentNamespace = entity.metadata.namespace ?? 'default';
   const { error, loading, value } = useDqlQuery(
     queryNamespace,
     queryName,

--- a/plugins/dql/src/components/kubernetes/KubernetesDeployments.tsx
+++ b/plugins/dql/src/components/kubernetes/KubernetesDeployments.tsx
@@ -32,7 +32,6 @@ export const KubernetesDeployments = ({
       queryId="dynatrace.kubernetes-deployments"
       emptyState={KubernetesDeploymentsEmptyState}
       pageSize={pageSize}
-      isKubernetes
     />
   );
 };

--- a/plugins/dql/src/components/kubernetes/KubernetesDeployments.tsx
+++ b/plugins/dql/src/components/kubernetes/KubernetesDeployments.tsx
@@ -32,6 +32,7 @@ export const KubernetesDeployments = ({
       queryId="dynatrace.kubernetes-deployments"
       emptyState={KubernetesDeploymentsEmptyState}
       pageSize={pageSize}
+      isKubernetes
     />
   );
 };

--- a/plugins/dql/src/components/kubernetes/KubernetesDeployments.tsx
+++ b/plugins/dql/src/components/kubernetes/KubernetesDeployments.tsx
@@ -15,6 +15,8 @@
  */
 import { DqlQuery } from '../DqlQuery';
 import { KubernetesDeploymentsEmptyState } from './KubernetesDeploymentsEmptyState';
+import { MissingAnnotationEmptyState } from '@backstage/core-components';
+import { useEntity } from '@backstage/plugin-catalog-react';
 import React from 'react';
 
 type KubernetesDeploymentsProps = {
@@ -22,10 +24,36 @@ type KubernetesDeploymentsProps = {
   pageSize?: number;
 };
 
+const KUBERNETES_ANNOTATION = 'backstage.io/kubernetes-id';
+const KUBERNETES_LABEL_SELECTOR_QUERY_ANNOTATION =
+  'backstage.io/kubernetes-label-selector';
+
 export const KubernetesDeployments = ({
   title = 'Kubernetes Deployments',
   pageSize,
 }: KubernetesDeploymentsProps) => {
+  const { entity } = useEntity();
+  const kubernetesAnnotationValue =
+    entity.metadata.annotations?.[KUBERNETES_ANNOTATION];
+
+  const kubernetesLabelSelectorQueryAnnotationValue =
+    entity.metadata.annotations?.[KUBERNETES_LABEL_SELECTOR_QUERY_ANNOTATION];
+
+  if (
+    !kubernetesAnnotationValue &&
+    !kubernetesLabelSelectorQueryAnnotationValue
+  ) {
+    return (
+      <>
+        <MissingAnnotationEmptyState annotation={KUBERNETES_ANNOTATION} />
+        <h1>
+          Or use a label selector query, which takes precedence over the
+          previous annotation
+        </h1>
+      </>
+    );
+  }
+
   return (
     <DqlQuery
       title={title}

--- a/plugins/dql/src/components/kubernetes/KubernetesDeploymentsEmptyState.tsx
+++ b/plugins/dql/src/components/kubernetes/KubernetesDeploymentsEmptyState.tsx
@@ -29,14 +29,13 @@ export const KubernetesDeploymentsEmptyState = ({
   [Dynatrace documentation](https://docs.dynatrace.com/docs/setup-and-configuration/dynatrace-oneagent)
   for more information.
 
-  Also, make sure that the \`backstage.io/component\` label is set to
-  \`${componentName}\` on your Kubernetes deployments:
+  Also, make sure that the annotation \`backstage.io/kubernetes-id\` or \`backstage.io/kubernetes-label-selector\` is set on your Backstage component:
 
   \`\`\`yaml
   metadata:
-    name: ${componentName}-deployment
-    labels:
-      backstage.io/component: "${componentName}"
+    name: ${componentName}
+    annotations:
+      backstage.io/kubernetes-id: "yourid"
   \`\`\`
 
   If you recently added the component, it may take a few minutes for

--- a/plugins/dql/src/components/kubernetes/KubernetesDeploymentsEmptyState.tsx
+++ b/plugins/dql/src/components/kubernetes/KubernetesDeploymentsEmptyState.tsx
@@ -21,7 +21,7 @@ export const KubernetesDeploymentsEmptyState = ({
   componentName,
 }: EmptyStateProps) => {
   const message = `# No Kubernetes resources
-  No resources on any known cluster for ${componentName}`;
+  No resources on any monitored Kubernetes cluster for ${componentName} found.`;
 
   return <DynatraceMarkdownText content={message} />;
 };

--- a/plugins/dql/src/components/kubernetes/KubernetesDeploymentsEmptyState.tsx
+++ b/plugins/dql/src/components/kubernetes/KubernetesDeploymentsEmptyState.tsx
@@ -19,11 +19,10 @@ import React from 'react';
 
 export const KubernetesDeploymentsEmptyState = ({
   componentName,
-  componentNamespace,
 }: EmptyStateProps) => {
   const message = `# We could not find any Kubernetes deployments
 
-  Dynatrace does not have any data for component \`${componentNamespace}.${componentName}\`.
+  Dynatrace does not have any data for component \`${componentName}\`.
 
   To start tracking Kubernetes deployments, you need to deploy the Dynatrace OneAgent
   Operator to your cluster. See the
@@ -31,13 +30,13 @@ export const KubernetesDeploymentsEmptyState = ({
   for more information.
 
   Also, make sure that the \`backstage.io/component\` label is set to
-  \`${componentNamespace}.${componentName}\` on your Kubernetes deployments:
+  \`${componentName}\` on your Kubernetes deployments:
 
   \`\`\`yaml
   metadata:
     name: ${componentName}-deployment
     labels:
-      backstage.io/component: "${componentNamespace}.${componentName}"
+      backstage.io/component: "${componentName}"
   \`\`\`
 
   If you recently added the component, it may take a few minutes for

--- a/plugins/dql/src/components/kubernetes/KubernetesDeploymentsEmptyState.tsx
+++ b/plugins/dql/src/components/kubernetes/KubernetesDeploymentsEmptyState.tsx
@@ -20,26 +20,8 @@ import React from 'react';
 export const KubernetesDeploymentsEmptyState = ({
   componentName,
 }: EmptyStateProps) => {
-  const message = `# We could not find any Kubernetes deployments
-
-  Dynatrace does not have any data for component \`${componentName}\`.
-
-  To start tracking Kubernetes deployments, you need to deploy the Dynatrace OneAgent
-  Operator to your cluster. See the
-  [Dynatrace documentation](https://docs.dynatrace.com/docs/setup-and-configuration/dynatrace-oneagent)
-  for more information.
-
-  Also, make sure that the annotation \`backstage.io/kubernetes-id\` or \`backstage.io/kubernetes-label-selector\` is set on your Backstage component:
-
-  \`\`\`yaml
-  metadata:
-    name: ${componentName}
-    annotations:
-      backstage.io/kubernetes-id: "yourid"
-  \`\`\`
-
-  If you recently added the component, it may take a few minutes for
-  Dynatrace to start reporting data.`;
+  const message = `# No Kubernetes resources
+  No resources on any known cluster for ${componentName}`;
 
   return <DynatraceMarkdownText content={message} />;
 };

--- a/plugins/dql/src/components/types.ts
+++ b/plugins/dql/src/components/types.ts
@@ -16,7 +16,6 @@
 
 export type EmptyStateProps = {
   componentName: string;
-  componentNamespace: string;
   queryName: string;
   queryNamespace: string;
 };

--- a/plugins/dql/src/hooks/useDqlQuery.test.tsx
+++ b/plugins/dql/src/hooks/useDqlQuery.test.tsx
@@ -54,6 +54,8 @@ describe('usDqlQuery', () => {
       'queryName',
       'componentName',
       'componentNamespace',
+      undefined,
+      undefined,
     );
     expect(result.current.value).toEqual([]);
   });

--- a/plugins/dql/src/hooks/useDqlQuery.test.tsx
+++ b/plugins/dql/src/hooks/useDqlQuery.test.tsx
@@ -29,6 +29,7 @@ const wrapper = ({ children }: { children: ReactNode }) => (
     {children}
   </TestApiProvider>
 );
+const mockedEntityRef = 'component:default/example';
 
 describe('usDqlQuery', () => {
   beforeEach(() => {
@@ -37,13 +38,7 @@ describe('usDqlQuery', () => {
 
   it('should delegate to dqlQueryApi and return the result of the query', async () => {
     const { result, waitForNextUpdate } = renderHook(
-      () =>
-        useDqlQuery(
-          'queryNamespace',
-          'queryName',
-          'componentName',
-          'componentNamespace',
-        ),
+      () => useDqlQuery('queryNamespace', 'queryName', mockedEntityRef),
       { wrapper },
     );
 
@@ -51,26 +46,13 @@ describe('usDqlQuery', () => {
 
     expect(MockDqlQueryApi.getData).toHaveBeenCalledWith<
       Parameters<DqlQueryApi['getData']>
-    >(
-      'queryNamespace',
-      'queryName',
-      'componentName',
-      'componentNamespace',
-      undefined,
-      undefined,
-    );
+    >('queryNamespace', 'queryName', mockedEntityRef);
     expect(result.current.value).toEqual([]);
   });
 
   it('should return loading true while the query is running', async () => {
     const { result, waitForNextUpdate } = renderHook(
-      () =>
-        useDqlQuery(
-          'queryNamespace',
-          'queryName',
-          'componentName',
-          'componentNamespace',
-        ),
+      () => useDqlQuery('queryNamespace', 'queryName', mockedEntityRef),
       { wrapper },
     );
 
@@ -84,13 +66,7 @@ describe('usDqlQuery', () => {
     MockDqlQueryApi.getData.mockRejectedValue(error);
 
     const { result, waitForNextUpdate } = renderHook(
-      () =>
-        useDqlQuery(
-          'queryNamespace',
-          'queryName',
-          'componentName',
-          'componentNamespace',
-        ),
+      () => useDqlQuery('queryNamespace', 'queryName', mockedEntityRef),
       { wrapper },
     );
 

--- a/plugins/dql/src/hooks/useDqlQuery.test.tsx
+++ b/plugins/dql/src/hooks/useDqlQuery.test.tsx
@@ -56,6 +56,7 @@ describe('usDqlQuery', () => {
       'componentNamespace',
       undefined,
       undefined,
+      undefined,
     );
     expect(result.current.value).toEqual([]);
   });

--- a/plugins/dql/src/hooks/useDqlQuery.test.tsx
+++ b/plugins/dql/src/hooks/useDqlQuery.test.tsx
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { dqlQueryApiRef } from '../api';
+import { DqlQueryApi, dqlQueryApiRef } from '../api';
 import { useDqlQuery } from './useDqlQuery';
 import { TestApiProvider } from '@backstage/test-utils';
 import { TabularData } from '@dynatrace/backstage-plugin-dql-common';
@@ -49,12 +49,13 @@ describe('usDqlQuery', () => {
 
     await waitForNextUpdate();
 
-    expect(MockDqlQueryApi.getData).toHaveBeenCalledWith(
+    expect(MockDqlQueryApi.getData).toHaveBeenCalledWith<
+      Parameters<DqlQueryApi['getData']>
+    >(
       'queryNamespace',
       'queryName',
       'componentName',
       'componentNamespace',
-      undefined,
       undefined,
       undefined,
     );

--- a/plugins/dql/src/hooks/useDqlQuery.ts
+++ b/plugins/dql/src/hooks/useDqlQuery.ts
@@ -22,6 +22,7 @@ export const useDqlQuery = (
   queryName: string,
   componentName: string,
   componentNamespace: string,
+  annotations?: Record<string, string | undefined>,
 ) => {
   const dqlQueryApi = useApi(dqlQueryApiRef);
 
@@ -31,6 +32,8 @@ export const useDqlQuery = (
       queryName,
       componentName,
       componentNamespace,
+      annotations?.['backstage.io/kubernetes-id'],
+      annotations?.['backstage.io/kubernetes-label-selector'],
     );
   }, [dqlQueryApi, namespace, queryName, componentName, componentNamespace]);
 

--- a/plugins/dql/src/hooks/useDqlQuery.ts
+++ b/plugins/dql/src/hooks/useDqlQuery.ts
@@ -21,7 +21,7 @@ export const useDqlQuery = (
   namespace: string,
   queryName: string,
   componentName: string,
-  componentNamespace: string,
+  componentNamespace?: string,
   annotations?: Record<string, string | undefined>,
 ) => {
   const dqlQueryApi = useApi(dqlQueryApiRef);

--- a/plugins/dql/src/hooks/useDqlQuery.ts
+++ b/plugins/dql/src/hooks/useDqlQuery.ts
@@ -32,6 +32,7 @@ export const useDqlQuery = (
       queryName,
       componentName,
       componentNamespace,
+      annotations?.['backstage.io/kubernetes-namespace'],
       annotations?.['backstage.io/kubernetes-id'],
       annotations?.['backstage.io/kubernetes-label-selector'],
     );

--- a/plugins/dql/src/hooks/useDqlQuery.ts
+++ b/plugins/dql/src/hooks/useDqlQuery.ts
@@ -20,22 +20,13 @@ import useAsync from 'react-use/lib/useAsync';
 export const useDqlQuery = (
   namespace: string,
   queryName: string,
-  componentName: string,
-  componentNamespace?: string,
-  annotations?: Record<string, string | undefined>,
+  entityRef: string,
 ) => {
   const dqlQueryApi = useApi(dqlQueryApiRef);
 
   const { value, loading, error } = useAsync(async () => {
-    return await dqlQueryApi.getData(
-      namespace,
-      queryName,
-      componentName,
-      componentNamespace,
-      annotations?.['backstage.io/kubernetes-id'],
-      annotations?.['backstage.io/kubernetes-label-selector'],
-    );
-  }, [dqlQueryApi, namespace, queryName, componentName, componentNamespace]);
+    return await dqlQueryApi.getData(namespace, queryName, entityRef);
+  }, [dqlQueryApi, namespace, queryName, entityRef]);
 
   return {
     error,

--- a/plugins/dql/src/hooks/useDqlQuery.ts
+++ b/plugins/dql/src/hooks/useDqlQuery.ts
@@ -32,7 +32,6 @@ export const useDqlQuery = (
       queryName,
       componentName,
       componentNamespace,
-      annotations?.['backstage.io/kubernetes-namespace'],
       annotations?.['backstage.io/kubernetes-id'],
       annotations?.['backstage.io/kubernetes-label-selector'],
     );


### PR DESCRIPTION
# Introduction
Added three different optional filters to the kubernetes DQL query via the `additionalFilter` placeholder.
- The namespace is now compared with the component annotation `backstage.io/kubernetes-namespace`. For non-kubernetes queries the metadata namespace is used and fallback to `default`. The following filter is added `| filter namespace.id == "{namespace}"`
- The kubernetes id is now compared with the component annotation `backstage.io/kubernetes-id`. The optional filter is added via ``| filter workload.labels[`backstage.io/kubernetes-id`] == "{kubernetesId}"``
- The kubernetes label is now compared with the component annotation `backstage.io/kubernetes-label-selector`. The annotation `label1=value1,label2=value2` will resolve to to ``| filter workload.labels[`label1`] == "value1" AND workload.labels[`label2`] == "value2"``


Also
- One of the labels `backstage.io/kubernetes-id`, `backstage.io/kubernetes-label-selector` is now required for the kubernetes query
- If a kubernetes-label-selector is given, the kubernetes-id is ignored.
- Removed the component namespace fallback to `default` for kubernetes queries. We want to query all namespaces if nothing is defined.

#### :heavy_check_mark: Common checklist

- [x] Added tests for new functionality and regression tests for bug fixes
- [ ] Screenshots of before and after attached (for UI changes)
- [ ] Added or updated documentation (if applicable)
- [ ] Helpful resources linked (if applicable)
