### PR TITLE
chore: improve error handling

### DIFF
--- a/plugins/dql-backend/src/service/dynatraceApi.ts
+++ b/plugins/dql-backend/src/service/dynatraceApi.ts
@@ -75,7 +75,10 @@ const executeQuery = async (
       body: JSON.stringify(dql),
     },
   );
-  return await queryExecRes.json();
+  if (!queryExecRes.ok) {
+    throw new Error(await queryExecRes.text().catch(() => ''));
+  }
+  return queryExecRes.json();
 };
 
 const pollQuery = async <T>(


### PR DESCRIPTION
# Introduction

<!--- Give a short introduction for this PR and link to additional helpful resources -->

## Technical solution before this PR

The polling request failed, if the request before did not return a requestToken (e.g., the fetch call returned 401, 403, 429, etc.).

## Technical solution after this PR

The polling request is not executed if the previous request fails.
The correct error is now returned from the backend

#### :heavy_check_mark: Common checklist

- [ ] Added tests for new functionality and regression tests for bug fixes
- [ ] Screenshots of before and after attached (for UI changes)
- [ ] Added or updated documentation (if applicable)
- [ ] Helpful resources linked (if applicable)
