### PR TITLE
Ca 11446

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,6 +298,47 @@ by its ID with the `custom.` prefix:
 />
 ```
 
+### Custom Queries within catalog-info.yaml file of the Backstage Entity
+
+You can also register your custom queries in the catalog-info.yaml file.
+
+```yaml
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: demo-backstage
+  description: Backstage Demo instance.
+  annotations:
+    backstage.io/kubernetes-id: kubernetescustom
+spec:
+  type: website
+  owner: user:default/mjakl
+  lifecycle: experimental
+  system: integrations
+  queries:
+    - name: Fetch all Davis events 1
+      query: >
+        fetch events | filter event.kind == "DAVIS_EVENT" | fields event.kind,
+        timestamp
+```
+
+As mentioned before, queries can contain placeholders. In the catalog-info.yaml
+file, the placeholders are prefixed with a single `$`. For example:
+
+- `${environmentName}`
+- `${environmentUrl}`
+
+To include the result tables for the custom queries of the entity, you would
+use:
+
+```jsx
+<EntityCatalogInfoQueryCard />
+```
+
+This component displays a result table for each query. The order in which the
+tables are displayed depends on the order of the entity's queries defined in the
+catalog-info.yaml file.
+
 ### Backlink to Dynatrace
 
 To link from a table cell to a Dynatrace app, the DQL query must contain a

--- a/README.md
+++ b/README.md
@@ -253,7 +253,8 @@ In this case, the guardian tag should be:
 component: demo-backstage
 ```
 
-[`How to create a SRG?`](https://docs.dynatrace.com/docs/shortlink/guardian-create-srg#create-a-guardian-from-a-template)
+See
+[How to create a SRG?](https://docs.dynatrace.com/docs/shortlink/guardian-create-srg#create-a-guardian-from-a-template).
 
 The query for fetching the monitoring data for Kubernetes deployments is defined
 here: [`dynatrace.srg-validations`](plugins/dql-backend/src/service/queries.ts).

--- a/README.md
+++ b/README.md
@@ -224,6 +224,41 @@ here:
 [`dynatrace.kubernetes-deployments`](plugins/dql-backend/src/service/queries.ts).
 You can change this query for all cards or override it using a custom query.
 
+### SRG Validations Use Case
+
+Using the `EntitySrgValidationsCard`, you can see the validations of the site
+reliability guardians in your Dynatrace environment.
+
+```jsx
+<EntitySrgValidationsCard title="SRG Release Validations" />
+```
+
+_Convention:_ Site Reliability Guardian (SRG) validations are listed for the
+corresponding Backstage component. Each guardian must have a tag with the key
+`component` and the value should match the `metadata.name` property defined in
+the component's `catalog-info.yaml` file.
+
+For example, consider the following `catalog-info.yaml` file:
+
+```yaml
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: demo-backstage
+```
+
+In this case, the guardian tag should be:
+
+```yaml
+component: demo-backstage
+```
+
+[`How to create a SRG?`](https://docs.dynatrace.com/docs/shortlink/guardian-create-srg#create-a-guardian-from-a-template)
+
+The query for fetching the monitoring data for Kubernetes deployments is defined
+here: [`dynatrace.srg-validations`](plugins/dql-backend/src/service/queries.ts).
+You can change this query for all cards or override it using a custom query.
+
 ### Custom Queries
 
 You can also register your custom queries and use them with

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -10,6 +10,33 @@ spec:
   owner: user:default/mjakl
   lifecycle: experimental
   system: integrations
+  queries:
+    - name: Error Logs
+      query: >
+        fetch logs, from: -2d
+                | filter status == "ERROR"
+                | sort timestamp desc
+                | fieldsAdd content=if(isNull(content), "N/A", else: content)
+                | fieldsAdd source=if(isNull(log.source), "N/A", else: log.source)
+                | fieldsAdd host=if(isNull(host.name), "N/A", else: host.name)
+                | fieldsKeep timestamp, source, content, host
+    - name: Problem Events
+      query: >
+        fetch events, from: -2d
+                | filter event.kind=="DAVIS_PROBLEM"
+                | fieldsAdd category=if(isNull(event.category), "N/A", else: event.category)
+                | fieldsAdd id=if(isNull(event.id), "N/A", else: event.id)
+                | fieldsAdd status=if(isNull(event.status), "N/A", else: event.status)
+                | fieldsAdd name=if(isNull(event.name), "N/A", else: event.name)
+                | fieldsKeep timestamp, event.category, id, name, status
+    - name: Security Vulnerabilities
+      query: >
+        fetch events, from: -2d
+                | filter event.provider=="Dynatrace"
+                | filter event.kind=="SECURITY_EVENT"
+                | filter event.type=="VULNERABILITY_STATUS_CHANGE_EVENT"
+                | filter event.level=="VULNERABILITY"
+                | fieldsKeep timestamp, event.status, vulnerability.display_id, event.id, vulnerability.title, vulnerability.risk.level, vulnerability.display_id
 ---
 apiVersion: backstage.io/v1alpha1
 kind: Component

--- a/packages/app/src/components/catalog/EntityPage.tsx
+++ b/packages/app/src/components/catalog/EntityPage.tsx
@@ -74,6 +74,7 @@ import {
   EntityDqlQueryCard,
   EntityKubernetesDeploymentsCard,
 } from '@dynatrace/backstage-plugin-dql';
+import { EntitySrgValidationsCard } from '@dynatrace/backstage-plugin-dql/src/plugin';
 import { Button, Grid } from '@material-ui/core';
 import React from 'react';
 
@@ -240,6 +241,9 @@ const websiteEntityPage = (
       <TabbedLayout>
         <TabbedLayout.Route path="/kubernetes" title="Kubernetes Deployments">
           <EntityKubernetesDeploymentsCard title="Kubernetes Deployments with explicit title" />
+        </TabbedLayout.Route>
+        <TabbedLayout.Route path="/srg" title="SRG Release Validations">
+          <EntitySrgValidationsCard title="SRG Release Validations" />
         </TabbedLayout.Route>
         <TabbedLayout.Route path="/davis-events" title="Davis Events">
           <EntityDqlQueryCard

--- a/packages/app/src/components/catalog/EntityPage.tsx
+++ b/packages/app/src/components/catalog/EntityPage.tsx
@@ -70,6 +70,7 @@ import { EntityTechdocsContent } from '@backstage/plugin-techdocs';
 import { ReportIssue } from '@backstage/plugin-techdocs-module-addons-contrib';
 import { TechDocsAddons } from '@backstage/plugin-techdocs-react';
 import {
+  EntityCatalogInfoQueryCard,
   EntityDqlQueryCard,
   EntityKubernetesDeploymentsCard,
 } from '@dynatrace/backstage-plugin-dql';
@@ -245,6 +246,12 @@ const websiteEntityPage = (
             title="Davis Events"
             queryId="custom.davis-events"
           />
+        </TabbedLayout.Route>
+        <TabbedLayout.Route
+          path="/example-catalog-queries"
+          title="Example Catalog Queries"
+        >
+          <EntityCatalogInfoQueryCard />
         </TabbedLayout.Route>
       </TabbedLayout>
     </EntityLayout.Route>

--- a/plugins/dql-backend/src/service/queries.test.ts
+++ b/plugins/dql-backend/src/service/queries.test.ts
@@ -95,5 +95,20 @@ describe('queries', () => {
       // assert
       expect(query).toContain('| filter workload.labels[`label`] == "value"');
     });
+
+    it('should return the srg-query', () => {
+      // act
+      const query = dynatraceQueries[DynatraceQueryKeys.SRG_VALIDATIONS](
+        getEntity(),
+        defaultApiConfig,
+      );
+
+      // assert
+      expect(query).toContain('fetch bizevents');
+      expect(query).toContain(
+        '| filter event.provider == "dynatrace.site.reliability.guardian"',
+      );
+      expect(query).toContain('componentName');
+    });
   });
 });

--- a/plugins/dql-backend/src/service/router.ts
+++ b/plugins/dql-backend/src/service/router.ts
@@ -24,6 +24,7 @@ import { PluginEndpointDiscovery } from '@backstage/backend-common';
 import { LoggerService, AuthService } from '@backstage/backend-plugin-api';
 import { CatalogClient } from '@backstage/catalog-client';
 import { Config } from '@backstage/config';
+import { EntityQuery } from '@dynatrace/backstage-plugin-dql/src/components/types';
 import express from 'express';
 import Router from 'express-promise-router';
 
@@ -57,7 +58,7 @@ export const createRouter = async (
     const entity = await getEntityFromRequest(req, catalogClient, auth);
     const queryId: number = Number(req.params.queryId);
     const result = await queryExecutor.executeCustomCatalogQueries(
-      entity.spec?.queries?.at(queryId),
+      (entity.spec?.queries as EntityQuery[])?.[queryId],
       {
         componentNamespace: entity.metadata.namespace ?? 'default',
         componentName: entity.metadata.name,

--- a/plugins/dql-backend/src/service/router.ts
+++ b/plugins/dql-backend/src/service/router.ts
@@ -20,10 +20,10 @@ import {
   createLegacyAuthAdapters,
   errorHandler,
 } from '@backstage/backend-common';
-import { CatalogClient } from '@backstage/catalog-client';
-import { LoggerService, AuthService } from '@backstage/backend-plugin-api';
-import { Config } from '@backstage/config';
 import { PluginEndpointDiscovery } from '@backstage/backend-common';
+import { LoggerService, AuthService } from '@backstage/backend-plugin-api';
+import { CatalogClient } from '@backstage/catalog-client';
+import { Config } from '@backstage/config';
 import express from 'express';
 import Router from 'express-promise-router';
 
@@ -52,6 +52,20 @@ export const createRouter = async (
 
   const router = Router();
   router.use(express.json());
+
+  router.get('/catalog/:queryId', async (req, res) => {
+    const entity = await getEntityFromRequest(req, catalogClient, auth);
+    const queryId: number = Number(req.params.queryId);
+    const result = await queryExecutor.executeCustomCatalogQueries(
+      entity.spec?.queries?.at(queryId),
+      {
+        componentNamespace: entity.metadata.namespace ?? 'default',
+        componentName: entity.metadata.name,
+      },
+    );
+
+    return res.json(result);
+  });
 
   router.get('/custom/:queryId', async (req, res) => {
     const entity = await getEntityFromRequest(req, catalogClient, auth);

--- a/plugins/dql/src/components/CatalogInfoQuery.test.tsx
+++ b/plugins/dql/src/components/CatalogInfoQuery.test.tsx
@@ -1,0 +1,118 @@
+/**
+ * @license
+ * Copyright 2024 Dynatrace LLC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { CatalogInfoQuery } from './CatalogInfoQuery';
+import { Entity } from '@backstage/catalog-model';
+import { EmptyState } from '@backstage/core-components';
+import { EntityProvider } from '@backstage/plugin-catalog-react';
+import { renderInTestApp } from '@backstage/test-utils';
+import { screen } from '@testing-library/react';
+import React from 'react';
+
+jest.mock('./InternalDqlQuery', () => ({
+  InternalDqlQuery: jest.fn(() => <div data-testid="id"></div>),
+}));
+
+jest.mock('@backstage/core-components', () => ({
+  EmptyState: jest.fn(() => null),
+}));
+
+const mockEntity = (
+  name: string = 'example',
+  annotations?: Record<string, string>,
+  namespace?: string,
+): Entity => {
+  return {
+    apiVersion: 'backstage.io/v1alpha1',
+    kind: 'Component',
+    metadata: {
+      name,
+      description: 'backstage.io/example',
+      annotations,
+      namespace,
+    },
+    spec: {
+      lifecycle: 'production',
+      type: 'service',
+      owner: 'user:guest',
+      queries: [
+        {
+          name: 'dynatrace dql test query 1',
+          query: 'fetch bizevents',
+        },
+        {
+          name: 'dynatrace dql test query 2',
+          query: 'fetch bizevents',
+        },
+      ],
+    },
+  };
+};
+
+const mockEntityWithoutQueries = (
+  name: string = 'example',
+  annotations?: Record<string, string>,
+  namespace?: string,
+): Entity => {
+  return {
+    apiVersion: 'backstage.io/v1alpha1',
+    kind: 'Component',
+    metadata: {
+      name,
+      description: 'backstage.io/example',
+      annotations,
+      namespace,
+    },
+    spec: {
+      lifecycle: 'production',
+      type: 'service',
+      owner: 'user:guest',
+    },
+  };
+};
+
+type PrepareComponentProps = {
+  entity?: Entity;
+};
+
+const prepareComponent = async ({
+  entity = mockEntity(),
+}: PrepareComponentProps = {}) => {
+  return await renderInTestApp(
+    <EntityProvider entity={entity}>
+      <CatalogInfoQuery />
+    </EntityProvider>,
+  );
+};
+
+describe('CatalogInfoQuery', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('Should call the InternalDqlQuery twice, for both queries of the entity', async () => {
+    const entity = mockEntity();
+    await prepareComponent({ entity: entity });
+    expect(screen.queryAllByTestId('id').length).toBe(2);
+    expect(EmptyState).not.toHaveBeenCalled();
+  });
+
+  it('Should show the EmptyState for the entity, when no queries are defined.', async () => {
+    const entity = mockEntityWithoutQueries();
+    await prepareComponent({ entity: entity });
+    expect(screen.queryAllByTestId('id').length).toBe(0);
+    expect(EmptyState).toHaveBeenCalled();
+  });
+});

--- a/plugins/dql/src/components/CatalogInfoQuery.tsx
+++ b/plugins/dql/src/components/CatalogInfoQuery.tsx
@@ -1,0 +1,58 @@
+/**
+ * @license
+ * Copyright 2024 Dynatrace LLC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { InternalDqlQuery } from './InternalDqlQuery';
+import { EmptyStateProps, EntityQuery } from './types';
+import { EmptyState } from '@backstage/core-components';
+import { useEntity } from '@backstage/plugin-catalog-react';
+import React from 'react';
+
+export type CatalogInfoQueryProps = {
+  emptyState?: React.ComponentType<EmptyStateProps>;
+  pageSize?: number;
+};
+
+/**
+ * CatalogInfoQuery is a wrapper around the InternalDqlQueries from the entity, that provides error handling
+ * for invalid props.
+ * @param props DqlQueryProps
+ * @returns React.ReactElement either a InternalDqlQuery or an ErrorPanel
+ */
+export const CatalogInfoQuery = (props: CatalogInfoQueryProps) => {
+  const { entity } = useEntity();
+  const queries = (entity.spec?.queries as EntityQuery[]) || [];
+  return (
+    <>
+      {queries.length > 0 ? (
+        queries.map((query, index) => (
+          <InternalDqlQuery
+            key={index}
+            title={query.name}
+            queryNamespace={'catalog'}
+            queryName={index.toString()}
+            EmptyState={props.emptyState}
+            pageSize={props.pageSize}
+          />
+        ))
+      ) : (
+        <EmptyState
+          title="No queries defined in catalog-info.yaml for this entity."
+          missing="info"
+          description="You need to add queries for this entity in the catalog-info.yaml file."
+        ></EmptyState>
+      )}
+    </>
+  );
+};

--- a/plugins/dql/src/components/index.ts
+++ b/plugins/dql/src/components/index.ts
@@ -16,5 +16,7 @@
 
 export { DqlQuery } from './DqlQuery';
 export type { DqlQueryProps } from './DqlQuery';
+export { CatalogInfoQuery } from './CatalogInfoQuery';
+export type { CatalogInfoQueryProps } from './CatalogInfoQuery';
 export { KubernetesDeployments } from './kubernetes';
 export type { EmptyStateProps } from './types';

--- a/plugins/dql/src/components/srg/SrgValidations.tsx
+++ b/plugins/dql/src/components/srg/SrgValidations.tsx
@@ -13,11 +13,25 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import { DqlQuery } from '../DqlQuery';
+import { SrgValidationsEmptyState } from './SrgValidationsEmptyState';
+import React from 'react';
 
-export { DqlQuery } from './DqlQuery';
-export type { DqlQueryProps } from './DqlQuery';
-export { CatalogInfoQuery } from './CatalogInfoQuery';
-export type { CatalogInfoQueryProps } from './CatalogInfoQuery';
-export { KubernetesDeployments } from './kubernetes';
-export { SrgValidatons } from './srg';
-export type { EmptyStateProps } from './types';
+type SrgValidationsProps = {
+  title?: string;
+  pageSize?: number;
+};
+
+export const SrgValidatons = ({
+  title = 'Srg Validations',
+  pageSize,
+}: SrgValidationsProps) => {
+  return (
+    <DqlQuery
+      title={title}
+      queryId="dynatrace.srg-validations"
+      emptyState={SrgValidationsEmptyState}
+      pageSize={pageSize}
+    />
+  );
+};

--- a/plugins/dql/src/components/srg/SrgValidationsEmptyState.tsx
+++ b/plugins/dql/src/components/srg/SrgValidationsEmptyState.tsx
@@ -13,11 +13,19 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import { EmptyStateProps } from '..';
+import { DynatraceMarkdownText } from '../DynatraceMarkdownText';
+import React from 'react';
 
-export { DqlQuery } from './DqlQuery';
-export type { DqlQueryProps } from './DqlQuery';
-export { CatalogInfoQuery } from './CatalogInfoQuery';
-export type { CatalogInfoQueryProps } from './CatalogInfoQuery';
-export { KubernetesDeployments } from './kubernetes';
-export { SrgValidatons } from './srg';
-export type { EmptyStateProps } from './types';
+export const SrgValidationsEmptyState = ({
+  componentName,
+}: EmptyStateProps) => {
+  const message = `# No Site Reliability Guardian resources
+  No Site Reliability Guardians for ${componentName} found.
+  
+  Do not hesitate to integrate Site Reliability Guardians! 
+  [View this for more information.](https://docs.dynatrace.com/docs/platform-modules/automations/site-reliability-guardian)
+`;
+
+  return <DynatraceMarkdownText content={message} />;
+};

--- a/plugins/dql/src/components/srg/index.ts
+++ b/plugins/dql/src/components/srg/index.ts
@@ -14,10 +14,4 @@
  * limitations under the License.
  */
 
-export { DqlQuery } from './DqlQuery';
-export type { DqlQueryProps } from './DqlQuery';
-export { CatalogInfoQuery } from './CatalogInfoQuery';
-export type { CatalogInfoQueryProps } from './CatalogInfoQuery';
-export { KubernetesDeployments } from './kubernetes';
-export { SrgValidatons } from './srg';
-export type { EmptyStateProps } from './types';
+export { SrgValidatons } from './SrgValidations';

--- a/plugins/dql/src/components/types.ts
+++ b/plugins/dql/src/components/types.ts
@@ -19,3 +19,14 @@ export type EmptyStateProps = {
   queryName: string;
   queryNamespace: string;
 };
+
+export type EntityQuery = {
+  /**
+   * The description of the query.
+   */
+  name: string;
+  /**
+   * The query itself.
+   */
+  query: string;
+};

--- a/plugins/dql/src/index.ts
+++ b/plugins/dql/src/index.ts
@@ -16,6 +16,7 @@
 
 export {
   EntityDqlQueryCard,
+  EntityCatalogInfoQueryCard,
   EntityKubernetesDeploymentsCard,
   dqlQueryPlugin,
 } from './plugin';

--- a/plugins/dql/src/plugin.ts
+++ b/plugins/dql/src/plugin.ts
@@ -47,6 +47,15 @@ export const EntityDqlQueryCard = dqlQueryPlugin.provide(
   }),
 );
 
+export const EntityCatalogInfoQueryCard = dqlQueryPlugin.provide(
+  createComponentExtension({
+    name: 'EntityCatalogInfoQueryCard',
+    component: {
+      lazy: () => import('./components').then(m => m.CatalogInfoQuery),
+    },
+  }),
+);
+
 export const EntityKubernetesDeploymentsCard = dqlQueryPlugin.provide(
   createComponentExtension({
     name: 'EntityKubernetesDeploymentsCard',

--- a/plugins/dql/src/plugin.ts
+++ b/plugins/dql/src/plugin.ts
@@ -64,3 +64,12 @@ export const EntityKubernetesDeploymentsCard = dqlQueryPlugin.provide(
     },
   }),
 );
+
+export const EntitySrgValidationsCard = dqlQueryPlugin.provide(
+  createComponentExtension({
+    name: 'EntitySrgValidationsCard',
+    component: {
+      lazy: () => import('./components').then(m => m.SrgValidatons),
+    },
+  }),
+);

--- a/yarn.lock
+++ b/yarn.lock
@@ -24350,7 +24350,16 @@ string-length@^4.0.1:
     char-regex "^1.0.2"
     strip-ansi "^6.0.0"
 
-"string-width-cjs@npm:string-width@^4.2.0", "string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0":
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
+  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.1"
+
+"string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -24437,7 +24446,7 @@ string_decoder@~1.1.1:
   dependencies:
     safe-buffer "~5.1.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -24450,6 +24459,13 @@ strip-ansi@5.2.0:
   integrity sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==
   dependencies:
     ansi-regex "^4.1.0"
+
+strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
+  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
+  dependencies:
+    ansi-regex "^5.0.1"
 
 strip-ansi@^7.0.1, strip-ansi@^7.1.0:
   version "7.1.0"
@@ -26279,7 +26295,7 @@ wordwrap@^1.0.0:
   resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-1.0.0.tgz#27584810891456a4171c8d0226441ade90cbcaeb"
   integrity sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -26292,6 +26308,15 @@ wrap-ansi@^6.0.1, wrap-ansi@^6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
   integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
+  dependencies:
+    ansi-styles "^4.0.0"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
+
+wrap-ansi@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
+  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"


### PR DESCRIPTION
# Introduction

The Site Reliability Guardian validates new versions of a deployment (release) to find performance regression and ensure security objectives. These validation results are now queried from Dynatrace and listed by the plugin.

## Technical solution after this PR

An `EntitySrgValidationsCard` was implemented to see the validations of the SRG. 

#### :heavy_check_mark: Common checklist

- [ ] Added tests for new functionality and regression tests for bug fixes
- [ ] Screenshots of before and after attached (for UI changes)
- [ ] Added or updated documentation (if applicable)
- [ ] Helpful resources linked (if applicable)
