### PR TITLE
feat: SRG validation as default query

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,6 +298,47 @@ by its ID with the `custom.` prefix:
 />
 ```
 
+### Custom Queries within catalog-info.yaml file of the Backstage Entity
+
+You can also register your custom queries in the catalog-info.yaml file.
+
+```yaml
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: demo-backstage
+  description: Backstage Demo instance.
+  annotations:
+    backstage.io/kubernetes-id: kubernetescustom
+spec:
+  type: website
+  owner: user:default/mjakl
+  lifecycle: experimental
+  system: integrations
+  queries:
+    - name: Fetch all Davis events 1
+      query: >
+        fetch events | filter event.kind == "DAVIS_EVENT" | fields event.kind,
+        timestamp
+```
+
+As mentioned before, queries can contain placeholders. In the catalog-info.yaml
+file, the placeholders are prefixed with a single `$`. For example:
+
+- `${environmentName}`
+- `${environmentUrl}`
+
+To include the result tables for the custom queries of the entity, you would
+use:
+
+```jsx
+<EntityCatalogInfoQueryCard />
+```
+
+This component displays a result table for each query. The order in which the
+tables are displayed depends on the order of the entity's queries defined in the
+catalog-info.yaml file.
+
 ### Backlink to Dynatrace
 
 To link from a table cell to a Dynatrace app, the DQL query must contain a

--- a/README.md
+++ b/README.md
@@ -224,6 +224,62 @@ here:
 [`dynatrace.kubernetes-deployments`](plugins/dql-backend/src/service/queries.ts).
 You can change this query for all cards or override it using a custom query.
 
+### Site Reliability Guardian Validations
+
+Using the `EntityDqlQueryCard` with the queryId `dynatrace.srg-validations`, you
+can see the validations of the site reliability guardians in your Dynatrace
+environment.
+
+```jsx
+<EntityDqlQueryCard
+  title="Site Reliability Guardian Validations"
+  queryId="dynatrace.srg-validations"
+/>
+```
+
+To filter for specific guardians, you can filter tags defined in the
+`metadata.annotations` property of the `catalog-info.yaml` file under the key
+`dynatrace.com/guardian-tags`.
+
+```yaml
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: demo-backstage
+  description: Backstage Demo instance.
+  annotations:
+    backstage.io/kubernetes-id: kubernetescustom
+    dynatrace.com/guardian-tags: 'service=my-service,stage=development,novalue'
+```
+
+There are two ways to filter tags:
+
+1. **Key-Value Match:** The tag must match both the key and the value. For
+   example, the key `service` must have the value `my-service`.
+2. **Key Exists:** The tag key must exist with any value. For example, the key
+   `novalue`.
+
+The difference between these filtering methods is indicated by the presence of
+the `=` symbol.
+
+For the example provided above, the filtered guardian should have at least these
+tags:
+
+```yaml
+service: my-service
+stage: development
+novalue:
+```
+
+See
+[How to create a Site Reliability Guardian](https://docs.dynatrace.com/docs/shortlink/guardian-create-srg#create-a-guardian-from-a-template)
+and [Guardian tags](https://docs.dynatrace.com/docs/shortlink/srg-landing#tags).
+
+The query for fetching the monitoring data for Site Reliability Guardian
+validations is defined here:
+[`dynatrace.srg-validations`](plugins/dql-backend/src/service/queries.ts). You
+can change this query for all cards or override it using a custom query.
+
 ### Custom Queries
 
 You can also register your custom queries and use them with

--- a/README.md
+++ b/README.md
@@ -316,17 +316,23 @@ spec:
   lifecycle: experimental
   system: integrations
   queries:
-    - name: Fetch all Davis events 1
+    - name: Problem Events
       query: >
-        fetch events | filter event.kind == "DAVIS_EVENT" | fields event.kind,
-        timestamp
+        fetch events, from: -2d
+              | filter event.kind=="DAVIS_PROBLEM"
+              | fieldsAdd category=if(isNull(event.category), "N/A", else:
+        event.category)
+              | fieldsAdd id=if(isNull(event.id), "N/A", else: event.id)
+              | fieldsAdd status=if(isNull(event.status), "N/A", else:
+        event.status)
+              | fieldsAdd name=if(isNull(event.name), "N/A", else: event.name)
+              | fieldsKeep timestamp, event.category, id, name, status
 ```
 
 As mentioned before, queries can contain placeholders. In the catalog-info.yaml
-file, the placeholders are prefixed with a single `$`. For example:
-
-- `${environmentName}`
-- `${environmentUrl}`
+file, the placeholders are prefixed with a single `$`. Please find the supported
+placeholders listed
+[here](https://github.com/Dynatrace/backstage-plugin/blob/eac6adfe0c25fc7a4e5b0b7d05d5dc83464f3652/README.md#custom-queries).
 
 To include the result tables for the custom queries of the entity, you would
 use:

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -10,6 +10,33 @@ spec:
   owner: user:default/mjakl
   lifecycle: experimental
   system: integrations
+  queries:
+    - name: Error Logs
+      query: >
+        fetch logs, from: -2d
+                | filter status == "ERROR"
+                | sort timestamp desc
+                | fieldsAdd content=if(isNull(content), "N/A", else: content)
+                | fieldsAdd source=if(isNull(log.source), "N/A", else: log.source)
+                | fieldsAdd host=if(isNull(host.name), "N/A", else: host.name)
+                | fieldsKeep timestamp, source, content, host
+    - name: Problem Events
+      query: >
+        fetch events, from: -2d
+                | filter event.kind=="DAVIS_PROBLEM"
+                | fieldsAdd category=if(isNull(event.category), "N/A", else: event.category)
+                | fieldsAdd id=if(isNull(event.id), "N/A", else: event.id)
+                | fieldsAdd status=if(isNull(event.status), "N/A", else: event.status)
+                | fieldsAdd name=if(isNull(event.name), "N/A", else: event.name)
+                | fieldsKeep timestamp, event.category, id, name, status
+    - name: Security Vulnerabilities
+      query: >
+        fetch events, from: -2d
+                | filter event.provider=="Dynatrace"
+                | filter event.kind=="SECURITY_EVENT"
+                | filter event.type=="VULNERABILITY_STATUS_CHANGE_EVENT"
+                | filter event.level=="VULNERABILITY"
+                | fieldsKeep timestamp, event.status, vulnerability.display_id, event.id, vulnerability.title, vulnerability.risk.level, vulnerability.display_id
 ---
 apiVersion: backstage.io/v1alpha1
 kind: Component

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -5,6 +5,7 @@ metadata:
   description: Backstage Demo instance.
   annotations:
     backstage.io/kubernetes-id: kubernetescustom
+    dynatrace.com/guardian-tags: "service=my-service,stage=development,novalue"
 spec:
   type: website
   owner: user:default/mjakl

--- a/packages/app/src/components/catalog/EntityPage.tsx
+++ b/packages/app/src/components/catalog/EntityPage.tsx
@@ -241,6 +241,12 @@ const websiteEntityPage = (
         <TabbedLayout.Route path="/kubernetes" title="Kubernetes Deployments">
           <EntityKubernetesDeploymentsCard title="Kubernetes Deployments with explicit title" />
         </TabbedLayout.Route>
+        <TabbedLayout.Route path="/srg" title="Site Reliability Guardian">
+          <EntityDqlQueryCard
+            title="Site Reliability Guardian Validations"
+            queryId="dynatrace.srg-validations"
+          />
+        </TabbedLayout.Route>
         <TabbedLayout.Route path="/davis-events" title="Davis Events">
           <EntityDqlQueryCard
             title="Davis Events"

--- a/packages/app/src/components/catalog/EntityPage.tsx
+++ b/packages/app/src/components/catalog/EntityPage.tsx
@@ -70,6 +70,7 @@ import { EntityTechdocsContent } from '@backstage/plugin-techdocs';
 import { ReportIssue } from '@backstage/plugin-techdocs-module-addons-contrib';
 import { TechDocsAddons } from '@backstage/plugin-techdocs-react';
 import {
+  EntityCatalogInfoQueryCard,
   EntityDqlQueryCard,
   EntityKubernetesDeploymentsCard,
 } from '@dynatrace/backstage-plugin-dql';
@@ -245,6 +246,12 @@ const websiteEntityPage = (
             title="Davis Events"
             queryId="custom.davis-events"
           />
+        </TabbedLayout.Route>
+        <TabbedLayout.Route
+          path="/example-catalog-queries"
+          title="Example Catalog Queries"
+        >
+          <EntityCatalogInfoQueryCard />
         </TabbedLayout.Route>
       </TabbedLayout>
     </EntityLayout.Route>

--- a/plugins/dql-backend/src/service/queries.test.ts
+++ b/plugins/dql-backend/src/service/queries.test.ts
@@ -95,5 +95,19 @@ describe('queries', () => {
       // assert
       expect(query).toContain('| filter workload.labels[`label`] == "value"');
     });
+
+    it('should return the srg-query', () => {
+      // act
+      const query = dynatraceQueries[DynatraceQueryKeys.SRG_VALIDATIONS](
+        getEntity(),
+        defaultApiConfig,
+      );
+
+      // assert
+      expect(query).toContain('fetch bizevents');
+      expect(query).toContain(
+        '| filter event.provider == "dynatrace.site.reliability.guardian"',
+      );
+    });
   });
 });

--- a/plugins/dql-backend/src/service/queries.ts
+++ b/plugins/dql-backend/src/service/queries.ts
@@ -18,6 +18,7 @@ import { Entity } from '@backstage/catalog-model';
 
 export enum DynatraceQueryKeys {
   KUBERNETES_DEPLOYMENTS = 'kubernetes-deployments',
+  SRG_VALIDATIONS = 'srg-validations',
 }
 
 interface ApiConfig {
@@ -86,5 +87,55 @@ export const dynatraceQueries: Record<
       "%5C%22)%20%7C%20sort%20timestamp%20desc%22%2C%22title%22%3A%22Logs%22%7D")})
     | fieldsRemove id, name, workload.labels, cluster.id, namespace.id
     | fieldsAdd Environment = "${apiConfig.environmentName}"`;
+  },
+  [DynatraceQueryKeys.SRG_VALIDATIONS]: (entity, apiConfig) => {
+    const catalogTags =
+      entity.metadata.annotations?.['dynatrace.com/guardian-tags'];
+    let filterString = '';
+
+    if (catalogTags) {
+      const tags = catalogTags.split(',').map(tag => {
+        const [key, value] = tag.split('=');
+        if (value === undefined) {
+          return { [key]: undefined };
+        }
+        return { [key]: value || '' };
+      });
+
+      if (tags.length > 0) {
+        filterString += '| filter ';
+        filterString += tags
+          .map(tag => {
+            const key = Object.keys(tag)[0];
+            const value = tag[key];
+            return value !== undefined
+              ? `in (tags[${key}], "${value}")`
+              : `isNotNull(tags[${key}])`;
+          })
+          .join(' AND ');
+      }
+    }
+
+    return `
+    fetch bizevents, from: -2d
+    | filter event.provider == "dynatrace.site.reliability.guardian"
+    | filter event.type == "guardian.validation.finished"
+    | parse validation.summary, "JSON:summary"
+    | parse execution_context, "JSON:context"
+    | parse guardian.tags, "JSON:tags"
+    ${filterString}
+    | fieldsAdd Version = if(isNull(context[version]), "N/A", else: context[version])
+    | fieldsRename \`Validation Result\` = validation.status
+    | fieldsAdd Error = summary[error], Fail = summary[fail], Warning = summary[warning], Pass = summary[pass], Info = summary[info]
+    | fieldsAdd Environment = "${apiConfig.environmentName}"
+    | fieldsAdd Link = record({type="link", text="Open Validation", url=concat(
+      "${apiConfig.environmentUrl}",
+      "/ui/intent/dynatrace.site.reliability.guardian/view_validation#%7B%22guardian.id%22%3A%22",
+      guardian.id,
+      "%22%2C%22validation.id%22%3A%22",
+      validation.id,
+      "%22%7D")})
+    | fieldsKeep Fail, Error, Pass, Info, Warning, Link, \`Validation Result\`, Version, Environment
+    `;
   },
 };

--- a/plugins/dql-backend/src/service/queryExecutor.test.ts
+++ b/plugins/dql-backend/src/service/queryExecutor.test.ts
@@ -62,4 +62,26 @@ describe('queryExecutor', () => {
       expect(result).toEqual([]);
     });
   });
+
+  describe('Catalog Queries', () => {
+    it('should not throw an error if catalog queries are defined', async () => {
+      // act
+      const result = await executor.executeCustomCatalogQueries(
+        [
+          { name: 'query-1', query: 'fetch data' },
+          { name: 'query-2', query: 'fetch data' },
+        ],
+        inputVariables,
+      );
+      // assert
+      expect(result).toEqual([]);
+    });
+
+    it('should throw an error if no catalog query is defined', async () => {
+      // assert
+      await expect(() =>
+        executor.executeCustomCatalogQueries([], inputVariables),
+      ).rejects.toThrow();
+    });
+  });
 });

--- a/plugins/dql-backend/src/service/router.ts
+++ b/plugins/dql-backend/src/service/router.ts
@@ -24,6 +24,7 @@ import { PluginEndpointDiscovery } from '@backstage/backend-common';
 import { LoggerService, AuthService } from '@backstage/backend-plugin-api';
 import { CatalogClient } from '@backstage/catalog-client';
 import { Config } from '@backstage/config';
+import { EntityQuery } from '@dynatrace/backstage-plugin-dql/src/components/types';
 import express from 'express';
 import Router from 'express-promise-router';
 
@@ -57,7 +58,7 @@ export const createRouter = async (
     const entity = await getEntityFromRequest(req, catalogClient, auth);
     const queryId: number = Number(req.params.queryId);
     const result = await queryExecutor.executeCustomCatalogQueries(
-      entity.spec?.queries?.at(queryId),
+      (entity.spec?.queries as EntityQuery[])?.[queryId],
       {
         componentNamespace: entity.metadata.namespace ?? 'default',
         componentName: entity.metadata.name,

--- a/plugins/dql-backend/src/service/router.ts
+++ b/plugins/dql-backend/src/service/router.ts
@@ -54,17 +54,15 @@ export const createRouter = async (
   const router = Router();
   router.use(express.json());
 
-  router.get('/catalog/:queryId', async (req, res) => {
+  router.get('/catalog', async (req, res) => {
     const entity = await getEntityFromRequest(req, catalogClient, auth);
-    const queryId: number = Number(req.params.queryId);
     const result = await queryExecutor.executeCustomCatalogQueries(
-      (entity.spec?.queries as EntityQuery[])?.[queryId],
+      entity.spec?.queries as EntityQuery[],
       {
         componentNamespace: entity.metadata.namespace ?? 'default',
         componentName: entity.metadata.name,
       },
     );
-
     return res.json(result);
   });
 

--- a/plugins/dql-backend/src/service/router.ts
+++ b/plugins/dql-backend/src/service/router.ts
@@ -20,10 +20,10 @@ import {
   createLegacyAuthAdapters,
   errorHandler,
 } from '@backstage/backend-common';
-import { CatalogClient } from '@backstage/catalog-client';
-import { LoggerService, AuthService } from '@backstage/backend-plugin-api';
-import { Config } from '@backstage/config';
 import { PluginEndpointDiscovery } from '@backstage/backend-common';
+import { LoggerService, AuthService } from '@backstage/backend-plugin-api';
+import { CatalogClient } from '@backstage/catalog-client';
+import { Config } from '@backstage/config';
 import express from 'express';
 import Router from 'express-promise-router';
 
@@ -52,6 +52,20 @@ export const createRouter = async (
 
   const router = Router();
   router.use(express.json());
+
+  router.get('/catalog/:queryId', async (req, res) => {
+    const entity = await getEntityFromRequest(req, catalogClient, auth);
+    const queryId: number = Number(req.params.queryId);
+    const result = await queryExecutor.executeCustomCatalogQueries(
+      entity.spec?.queries?.at(queryId),
+      {
+        componentNamespace: entity.metadata.namespace ?? 'default',
+        componentName: entity.metadata.name,
+      },
+    );
+
+    return res.json(result);
+  });
 
   router.get('/custom/:queryId', async (req, res) => {
     const entity = await getEntityFromRequest(req, catalogClient, auth);

--- a/plugins/dql/dev/index.tsx
+++ b/plugins/dql/dev/index.tsx
@@ -66,16 +66,25 @@ class MockDqlQueryApi implements DqlQueryApi {
   async getData(): Promise<TabularData> {
     return exampleData;
   }
+  async getDataFromQueries(): Promise<TabularData[]> {
+    return [exampleData, exampleData];
+  }
 }
 
 class MockDqlQueryApiNoResult implements DqlQueryApi {
   async getData(): Promise<TabularData> {
     return [];
   }
+  async getDataFromQueries(): Promise<TabularData[]> {
+    return [[]];
+  }
 }
 
 class MockDqlQueryApiError implements DqlQueryApi {
   async getData(): Promise<TabularData> {
+    throw new Error('404 Not Found');
+  }
+  async getDataFromQueries(): Promise<TabularData[]> {
     throw new Error('404 Not Found');
   }
 }

--- a/plugins/dql/src/api/DqlQueryApiClient.test.ts
+++ b/plugins/dql/src/api/DqlQueryApiClient.test.ts
@@ -70,6 +70,14 @@ describe('DQLQueryApiClient', () => {
     );
 
     expect(discoveryApi.getBaseUrl).toHaveBeenCalledWith('dynatrace-dql');
+
+    await client.getDataFromQueries(
+      'namespace',
+      mockedEntityRef,
+      mockedIdentityToken,
+    );
+
+    expect(discoveryApi.getBaseUrl).toHaveBeenCalledWith('dynatrace-dql');
   });
 
   it('should encode the component parameter', async () => {
@@ -92,7 +100,7 @@ describe('DQLQueryApiClient', () => {
     expect(result).toEqual([]);
   });
 
-  it('should return the data from fetch', async () => {
+  it('should return the data from function getData()', async () => {
     const response = [{ column: 'value' }];
     mockFetchResponse(response);
     const discoveryApi = mockDiscoveryApiUrl('https://discovery-api.com');
@@ -105,6 +113,20 @@ describe('DQLQueryApiClient', () => {
       mockedIdentityToken,
     );
 
+    expect(result).toEqual(response);
+  });
+
+  it('should return the data from function getDataFromQueries()', async () => {
+    const response = [[{ column: 'value' }]];
+    mockFetchResponse(response);
+    const discoveryApi = mockDiscoveryApiUrl('https://discovery-api.com');
+    const client = new DqlQueryApiClient({ discoveryApi });
+
+    const result = await client.getDataFromQueries(
+      'queryNamespace',
+      mockedEntityRef,
+      mockedIdentityToken,
+    );
     expect(result).toEqual(response);
   });
 
@@ -126,6 +148,14 @@ describe('DQLQueryApiClient', () => {
         mockedIdentityToken,
       ),
     ).rejects.toThrow(/Unexpected token/);
+
+    await expect(
+      client.getDataFromQueries(
+        'queryNamespace',
+        mockedEntityRef,
+        mockedIdentityToken,
+      ),
+    ).rejects.toThrow(/Unexpected token/);
   });
 
   it('should reject for invalid TabularData', async () => {
@@ -137,6 +167,14 @@ describe('DQLQueryApiClient', () => {
       client.getData(
         'queryNamespace',
         'queryName',
+        mockedEntityRef,
+        mockedIdentityToken,
+      ),
+    ).rejects.toThrow();
+
+    await expect(
+      client.getDataFromQueries(
+        'queryNamespace',
         mockedEntityRef,
         mockedIdentityToken,
       ),
@@ -163,6 +201,14 @@ describe('DQLQueryApiClient', () => {
         mockedIdentityToken,
       ),
     ).rejects.toThrow(`Query queryNamespace/queryName does not exist.`);
+
+    await expect(
+      client.getDataFromQueries(
+        'queryNamespace',
+        mockedEntityRef,
+        mockedIdentityToken,
+      ),
+    ).rejects.toThrow(`Query queryNamespace does not exist.`);
   });
 
   it('should report any generic error to the frontend', async () => {
@@ -181,6 +227,14 @@ describe('DQLQueryApiClient', () => {
       client.getData(
         'queryNamespace',
         'queryName',
+        mockedEntityRef,
+        mockedIdentityToken,
+      ),
+    ).rejects.toThrow("Request failed with 500 It's broken");
+
+    await expect(
+      client.getDataFromQueries(
+        'queryNamespace',
         mockedEntityRef,
         mockedIdentityToken,
       ),

--- a/plugins/dql/src/api/types.ts
+++ b/plugins/dql/src/api/types.ts
@@ -22,4 +22,10 @@ export type DqlQueryApi = {
     entityRef: string,
     identityToken: string,
   ): Promise<TabularData>;
+
+  getDataFromQueries(
+    queryNamespace: string,
+    entityRef: string,
+    identityToken: string,
+  ): Promise<TabularData[]>;
 };

--- a/plugins/dql/src/components/CatalogInfoQuery.test.tsx
+++ b/plugins/dql/src/components/CatalogInfoQuery.test.tsx
@@ -1,0 +1,118 @@
+/**
+ * @license
+ * Copyright 2024 Dynatrace LLC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { CatalogInfoQuery } from './CatalogInfoQuery';
+import { Entity } from '@backstage/catalog-model';
+import { EmptyState } from '@backstage/core-components';
+import { EntityProvider } from '@backstage/plugin-catalog-react';
+import { renderInTestApp } from '@backstage/test-utils';
+import { screen } from '@testing-library/react';
+import React from 'react';
+
+jest.mock('./InternalDqlQuery', () => ({
+  InternalDqlQuery: jest.fn(() => <div data-testid="id"></div>),
+}));
+
+jest.mock('@backstage/core-components', () => ({
+  EmptyState: jest.fn(() => null),
+}));
+
+const mockEntity = (
+  name: string = 'example',
+  annotations?: Record<string, string>,
+  namespace?: string,
+): Entity => {
+  return {
+    apiVersion: 'backstage.io/v1alpha1',
+    kind: 'Component',
+    metadata: {
+      name,
+      description: 'backstage.io/example',
+      annotations,
+      namespace,
+    },
+    spec: {
+      lifecycle: 'production',
+      type: 'service',
+      owner: 'user:guest',
+      queries: [
+        {
+          name: 'dynatrace dql test query 1',
+          query: 'fetch bizevents',
+        },
+        {
+          name: 'dynatrace dql test query 2',
+          query: 'fetch bizevents',
+        },
+      ],
+    },
+  };
+};
+
+const mockEntityWithoutQueries = (
+  name: string = 'example',
+  annotations?: Record<string, string>,
+  namespace?: string,
+): Entity => {
+  return {
+    apiVersion: 'backstage.io/v1alpha1',
+    kind: 'Component',
+    metadata: {
+      name,
+      description: 'backstage.io/example',
+      annotations,
+      namespace,
+    },
+    spec: {
+      lifecycle: 'production',
+      type: 'service',
+      owner: 'user:guest',
+    },
+  };
+};
+
+type PrepareComponentProps = {
+  entity?: Entity;
+};
+
+const prepareComponent = async ({
+  entity = mockEntity(),
+}: PrepareComponentProps = {}) => {
+  return await renderInTestApp(
+    <EntityProvider entity={entity}>
+      <CatalogInfoQuery />
+    </EntityProvider>,
+  );
+};
+
+describe('CatalogInfoQuery', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('Should call the InternalDqlQuery twice, for both queries of the entity', async () => {
+    const entity = mockEntity();
+    await prepareComponent({ entity: entity });
+    expect(screen.queryAllByTestId('id').length).toBe(2);
+    expect(EmptyState).not.toHaveBeenCalled();
+  });
+
+  it('Should show the EmptyState for the entity, when no queries are defined.', async () => {
+    const entity = mockEntityWithoutQueries();
+    await prepareComponent({ entity: entity });
+    expect(screen.queryAllByTestId('id').length).toBe(0);
+    expect(EmptyState).toHaveBeenCalled();
+  });
+});

--- a/plugins/dql/src/components/CatalogInfoQuery.tsx
+++ b/plugins/dql/src/components/CatalogInfoQuery.tsx
@@ -1,0 +1,58 @@
+/**
+ * @license
+ * Copyright 2024 Dynatrace LLC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { InternalDqlQuery } from './InternalDqlQuery';
+import { EmptyStateProps, EntityQuery } from './types';
+import { EmptyState } from '@backstage/core-components';
+import { useEntity } from '@backstage/plugin-catalog-react';
+import React from 'react';
+
+export type CatalogInfoQueryProps = {
+  emptyState?: React.ComponentType<EmptyStateProps>;
+  pageSize?: number;
+};
+
+/**
+ * CatalogInfoQuery is a wrapper around the InternalDqlQueries from the entity, that provides error handling
+ * for invalid props.
+ * @param props DqlQueryProps
+ * @returns React.ReactElement either a InternalDqlQuery or an ErrorPanel
+ */
+export const CatalogInfoQuery = (props: CatalogInfoQueryProps) => {
+  const { entity } = useEntity();
+  const queries = (entity.spec?.queries as EntityQuery[]) || [];
+  return (
+    <>
+      {queries.length > 0 ? (
+        queries.map((query, index) => (
+          <InternalDqlQuery
+            key={index}
+            title={query.name}
+            queryNamespace={'catalog'}
+            queryName={index.toString()}
+            EmptyState={props.emptyState}
+            pageSize={props.pageSize}
+          />
+        ))
+      ) : (
+        <EmptyState
+          title="No queries defined in catalog-info.yaml for this entity."
+          missing="info"
+          description="You need to add queries for this entity in the catalog-info.yaml file."
+        ></EmptyState>
+      )}
+    </>
+  );
+};

--- a/plugins/dql/src/components/CatalogQueries.test.tsx
+++ b/plugins/dql/src/components/CatalogQueries.test.tsx
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { CatalogInfoQuery } from './CatalogInfoQuery';
+import { CatalogInfoQuery } from './CatalogQueries';
 import { Entity } from '@backstage/catalog-model';
 import { EmptyState } from '@backstage/core-components';
 import { EntityProvider } from '@backstage/plugin-catalog-react';
@@ -21,8 +21,8 @@ import { renderInTestApp } from '@backstage/test-utils';
 import { screen } from '@testing-library/react';
 import React from 'react';
 
-jest.mock('./InternalDqlQuery', () => ({
-  InternalDqlQuery: jest.fn(() => <div data-testid="id"></div>),
+jest.mock('./InternalCatalogQueries', () => ({
+  InternalCatalogQueries: jest.fn(() => <div data-testid="id"></div>),
 }));
 
 jest.mock('@backstage/core-components', () => ({
@@ -50,11 +50,11 @@ const mockEntity = (
       queries: [
         {
           name: 'dynatrace dql test query 1',
-          query: 'fetch bizevents',
+          query: 'fetch data',
         },
         {
           name: 'dynatrace dql test query 2',
-          query: 'fetch bizevents',
+          query: 'fetch data',
         },
       ],
     },
@@ -102,10 +102,10 @@ describe('CatalogInfoQuery', () => {
     jest.clearAllMocks();
   });
 
-  it('Should call the InternalDqlQuery twice, for both queries of the entity', async () => {
+  it('Should call the InternalCatalogQueries once, for both queries of the entity', async () => {
     const entity = mockEntity();
     await prepareComponent({ entity: entity });
-    expect(screen.queryAllByTestId('id').length).toBe(2);
+    expect(screen.queryAllByTestId('id').length).toBe(1);
     expect(EmptyState).not.toHaveBeenCalled();
   });
 

--- a/plugins/dql/src/components/CatalogQueries.tsx
+++ b/plugins/dql/src/components/CatalogQueries.tsx
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { InternalDqlQuery } from './InternalDqlQuery';
+import { InternalCatalogQueries } from './InternalCatalogQueries';
 import { EmptyStateProps, EntityQuery } from './types';
 import { EmptyState } from '@backstage/core-components';
 import { useEntity } from '@backstage/plugin-catalog-react';
@@ -36,16 +36,12 @@ export const CatalogInfoQuery = (props: CatalogInfoQueryProps) => {
   return (
     <>
       {queries.length > 0 ? (
-        queries.map((query, index) => (
-          <InternalDqlQuery
-            key={index}
-            title={query.name}
-            queryNamespace={'catalog'}
-            queryName={index.toString()}
-            EmptyState={props.emptyState}
-            pageSize={props.pageSize}
-          />
-        ))
+        <InternalCatalogQueries
+          titles={queries.map(query => query.name)}
+          queryNamespace={'catalog'}
+          EmptyState={props.emptyState}
+          pageSize={props.pageSize}
+        ></InternalCatalogQueries>
       ) : (
         <EmptyState
           title="No queries defined in catalog-info.yaml for this entity."

--- a/plugins/dql/src/components/DqlEmptyState.tsx
+++ b/plugins/dql/src/components/DqlEmptyState.tsx
@@ -21,12 +21,19 @@ export const DqlEmptyState = ({
   componentName,
   queryName,
   queryNamespace,
+  isCatalogQuery = false,
 }: EmptyStateProps) => {
   const message = `# We turned up empty
 
-  Query \`${queryNamespace}.${queryName}\` did not return any data for
-  component \`${componentName}\`.
-
+  ${
+    isCatalogQuery
+      ? `Query named \`${queryName}\` defined in catalog-info.yaml 
+  for component \`${componentName}\` did not return any data.`
+      : `Query 
+  \`${queryNamespace}.${queryName}\` did not return any data for component 
+  \`${componentName}\`.`
+  }
+  
   If you recently added the component, it may take a few minutes for
   Dynatrace to start reporting data. If the component has been running
   for a while, it may not be reporting data. Please check that your

--- a/plugins/dql/src/components/DqlEmptyState.tsx
+++ b/plugins/dql/src/components/DqlEmptyState.tsx
@@ -22,6 +22,7 @@ export const DqlEmptyState = ({
   queryName,
   queryNamespace,
   isCatalogQuery = false,
+  additionalInformation = '',
 }: EmptyStateProps) => {
   const message = `# We turned up empty
 
@@ -38,7 +39,9 @@ export const DqlEmptyState = ({
   Dynatrace to start reporting data. If the component has been running
   for a while, it may not be reporting data. Please check that your
   component is indeed reporting data to Dynatrace and, in case you are
-  using custom queries, that the query is correct.`;
+  using custom queries, that the query is correct. 
+  
+  ${additionalInformation}`;
 
   return <DynatraceMarkdownText content={message} />;
 };

--- a/plugins/dql/src/components/InternalCatalogQueries.tsx
+++ b/plugins/dql/src/components/InternalCatalogQueries.tsx
@@ -1,0 +1,82 @@
+/**
+ * @license
+ * Copyright 2024 Dynatrace LLC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { useCatalogDqlQueries } from '../hooks/useCatalogDqlQueries';
+import { DqlEmptyState } from './DqlEmptyState';
+import { TabularDataTable } from './TabularDataTable';
+import { EmptyStateProps } from './types';
+import { stringifyEntityRef } from '@backstage/catalog-model';
+import { Progress, ResponseErrorPanel } from '@backstage/core-components';
+import { useEntity } from '@backstage/plugin-catalog-react';
+import React from 'react';
+
+export type InternalCatalogQueriesProps = {
+  titles: string[];
+  queryNamespace: string;
+  EmptyState?: React.ComponentType<EmptyStateProps>;
+  pageSize?: number;
+};
+
+export const InternalCatalogQueries = ({
+  titles,
+  queryNamespace,
+  EmptyState = DqlEmptyState,
+  pageSize,
+}: InternalCatalogQueriesProps) => {
+  const { entity } = useEntity();
+  const componentName = entity.metadata.name;
+
+  const { error, loading, value } = useCatalogDqlQueries(
+    queryNamespace,
+    stringifyEntityRef(entity),
+  );
+
+  if (loading) {
+    return <Progress />;
+  } else if (error) {
+    return <ResponseErrorPanel error={error} />;
+  }
+
+  if (!value || value.length === 0) {
+    return (
+      <EmptyState
+        componentName={componentName}
+        queryName={''}
+        queryNamespace={queryNamespace}
+      />
+    );
+  }
+
+  return (
+    <>
+      {value.map((queryData, index) =>
+        queryData.length > 0 ? (
+          <TabularDataTable
+            data={queryData}
+            title={titles[index]}
+            pageSize={pageSize}
+          ></TabularDataTable>
+        ) : (
+          <EmptyState
+            componentName={componentName}
+            queryName={titles[index]}
+            queryNamespace={queryNamespace}
+            isCatalogQuery={true}
+          />
+        ),
+      )}
+    </>
+  );
+};

--- a/plugins/dql/src/components/InternalDqlQuery.tsx
+++ b/plugins/dql/src/components/InternalDqlQuery.tsx
@@ -57,6 +57,14 @@ export const InternalDqlQuery = ({
         componentName={componentName}
         queryName={queryName}
         queryNamespace={queryNamespace}
+        additionalInformation={
+          `${queryNamespace}.${queryName}` === 'dynatrace.srg-validations'
+            ? `# No Site Reliability Guardian resources
+  No result received. If you don't use Site Reliability Guardians, do not hesitate to integrate them. 
+  [View this for more information.](https://docs.dynatrace.com/docs/platform-modules/automations/site-reliability-guardian)
+`
+            : ''
+        }
       />
     );
   }

--- a/plugins/dql/src/components/index.ts
+++ b/plugins/dql/src/components/index.ts
@@ -16,7 +16,7 @@
 
 export { DqlQuery } from './DqlQuery';
 export type { DqlQueryProps } from './DqlQuery';
-export { CatalogInfoQuery } from './CatalogInfoQuery';
-export type { CatalogInfoQueryProps } from './CatalogInfoQuery';
+export { CatalogInfoQuery } from './CatalogQueries';
+export type { CatalogInfoQueryProps } from './CatalogQueries';
 export { KubernetesDeployments } from './kubernetes';
 export type { EmptyStateProps } from './types';

--- a/plugins/dql/src/components/index.ts
+++ b/plugins/dql/src/components/index.ts
@@ -16,5 +16,7 @@
 
 export { DqlQuery } from './DqlQuery';
 export type { DqlQueryProps } from './DqlQuery';
+export { CatalogInfoQuery } from './CatalogInfoQuery';
+export type { CatalogInfoQueryProps } from './CatalogInfoQuery';
 export { KubernetesDeployments } from './kubernetes';
 export type { EmptyStateProps } from './types';

--- a/plugins/dql/src/components/types.ts
+++ b/plugins/dql/src/components/types.ts
@@ -18,6 +18,7 @@ export type EmptyStateProps = {
   componentName: string;
   queryName: string;
   queryNamespace: string;
+  isCatalogQuery?: boolean;
 };
 
 export type EntityQuery = {

--- a/plugins/dql/src/components/types.ts
+++ b/plugins/dql/src/components/types.ts
@@ -19,6 +19,7 @@ export type EmptyStateProps = {
   queryName: string;
   queryNamespace: string;
   isCatalogQuery?: boolean;
+  additionalInformation?: string;
 };
 
 export type EntityQuery = {

--- a/plugins/dql/src/components/types.ts
+++ b/plugins/dql/src/components/types.ts
@@ -19,3 +19,14 @@ export type EmptyStateProps = {
   queryName: string;
   queryNamespace: string;
 };
+
+export type EntityQuery = {
+  /**
+   * The description of the query.
+   */
+  name: string;
+  /**
+   * The query itself.
+   */
+  query: string;
+};

--- a/plugins/dql/src/hooks/useCatalogDqlQueries.test.tsx
+++ b/plugins/dql/src/hooks/useCatalogDqlQueries.test.tsx
@@ -1,0 +1,100 @@
+/**
+ * @license
+ * Copyright 2024 Dynatrace LLC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { DqlQueryApi, dqlQueryApiRef } from '../api';
+import { useCatalogDqlQueries } from './useCatalogDqlQueries';
+import { identityApiRef } from '@backstage/core-plugin-api';
+import { TestApiProvider } from '@backstage/test-utils';
+import { TabularData } from '@dynatrace/backstage-plugin-dql-common';
+import { renderHook } from '@testing-library/react-hooks';
+import React, { ReactNode } from 'react';
+
+const MockDqlQueryApi = {
+  getDataFromQueries: jest.fn().mockResolvedValue([] as TabularData[]),
+};
+const MockIdentityApi = {
+  getCredentials: jest.fn().mockResolvedValue({ token: 'mock-token' }),
+};
+
+const wrapper = ({ children }: { children: ReactNode }) => (
+  <TestApiProvider
+    apis={[
+      [dqlQueryApiRef, MockDqlQueryApi],
+      [identityApiRef, MockIdentityApi],
+    ]}
+  >
+    {children}
+  </TestApiProvider>
+);
+const mockedEntityRef = 'component:default/example';
+
+describe('useDqlQuery', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should delegate to dqlQueryApi and return the result of the query', async () => {
+    const { result, waitForNextUpdate } = renderHook(
+      () => useCatalogDqlQueries('queryNamespace', mockedEntityRef),
+      { wrapper },
+    );
+
+    await waitForNextUpdate();
+
+    expect(MockDqlQueryApi.getDataFromQueries).toHaveBeenCalledWith<
+      Parameters<DqlQueryApi['getDataFromQueries']>
+    >('queryNamespace', mockedEntityRef, expect.anything());
+    expect(result.current.value).toEqual([]);
+  });
+
+  it('should return loading true while the query is running', async () => {
+    const { result, waitForNextUpdate } = renderHook(
+      () => useCatalogDqlQueries('queryNamespace', mockedEntityRef),
+      { wrapper },
+    );
+
+    expect(result.current.loading).toBeTruthy();
+
+    await waitForNextUpdate();
+  });
+
+  it('should return error if the query fails', async () => {
+    const error = new Error('test');
+    MockDqlQueryApi.getDataFromQueries.mockRejectedValue(error);
+
+    const { result, waitForNextUpdate } = renderHook(
+      () => useCatalogDqlQueries('queryNamespace', mockedEntityRef),
+      { wrapper },
+    );
+
+    await waitForNextUpdate();
+
+    expect(result.current.error).toEqual(error);
+  });
+
+  it('should return error if identity api fails to retrieve credentials', async () => {
+    const error = new Error('Failed to get identity token');
+    MockIdentityApi.getCredentials.mockResolvedValue({});
+
+    const { result, waitForNextUpdate } = renderHook(
+      () => useCatalogDqlQueries('queryNamespace', mockedEntityRef),
+      { wrapper },
+    );
+
+    await waitForNextUpdate();
+
+    expect(result.current.error).toEqual(error);
+  });
+});

--- a/plugins/dql/src/hooks/useCatalogDqlQueries.tsx
+++ b/plugins/dql/src/hooks/useCatalogDqlQueries.tsx
@@ -1,0 +1,38 @@
+/**
+ * @license
+ * Copyright 2024 Dynatrace LLC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { dqlQueryApiRef } from '../api';
+import { useApi, identityApiRef } from '@backstage/core-plugin-api';
+import useAsync from 'react-use/lib/useAsync';
+
+export const useCatalogDqlQueries = (namespace: string, entityRef: string) => {
+  const dqlQueryApi = useApi(dqlQueryApiRef);
+  const identityApi = useApi(identityApiRef);
+
+  const { value, loading, error } = useAsync(async () => {
+    const { token } = await identityApi.getCredentials();
+    if (!token) {
+      throw new Error(`Failed to get identity token`);
+    }
+
+    return await dqlQueryApi.getDataFromQueries(namespace, entityRef, token);
+  }, [dqlQueryApi, namespace, entityRef]);
+
+  return {
+    error,
+    loading,
+    value,
+  };
+};

--- a/plugins/dql/src/index.ts
+++ b/plugins/dql/src/index.ts
@@ -16,6 +16,7 @@
 
 export {
   EntityDqlQueryCard,
+  EntityCatalogInfoQueryCard,
   EntityKubernetesDeploymentsCard,
   dqlQueryPlugin,
 } from './plugin';

--- a/plugins/dql/src/plugin.ts
+++ b/plugins/dql/src/plugin.ts
@@ -47,6 +47,15 @@ export const EntityDqlQueryCard = dqlQueryPlugin.provide(
   }),
 );
 
+export const EntityCatalogInfoQueryCard = dqlQueryPlugin.provide(
+  createComponentExtension({
+    name: 'EntityCatalogInfoQueryCard',
+    component: {
+      lazy: () => import('./components').then(m => m.CatalogInfoQuery),
+    },
+  }),
+);
+
 export const EntityKubernetesDeploymentsCard = dqlQueryPlugin.provide(
   createComponentExtension({
     name: 'EntityKubernetesDeploymentsCard',

--- a/yarn.lock
+++ b/yarn.lock
@@ -24350,7 +24350,16 @@ string-length@^4.0.1:
     char-regex "^1.0.2"
     strip-ansi "^6.0.0"
 
-"string-width-cjs@npm:string-width@^4.2.0", "string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0":
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
+  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.1"
+
+"string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -24437,7 +24446,7 @@ string_decoder@~1.1.1:
   dependencies:
     safe-buffer "~5.1.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -24450,6 +24459,13 @@ strip-ansi@5.2.0:
   integrity sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==
   dependencies:
     ansi-regex "^4.1.0"
+
+strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
+  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
+  dependencies:
+    ansi-regex "^5.0.1"
 
 strip-ansi@^7.0.1, strip-ansi@^7.1.0:
   version "7.1.0"
@@ -26279,7 +26295,7 @@ wordwrap@^1.0.0:
   resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-1.0.0.tgz#27584810891456a4171c8d0226441ade90cbcaeb"
   integrity sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -26292,6 +26308,15 @@ wrap-ansi@^6.0.1, wrap-ansi@^6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
   integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
+  dependencies:
+    ansi-styles "^4.0.0"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
+
+wrap-ansi@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
+  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"


### PR DESCRIPTION
# Introduction

resolves #107 

This branch already uses the changes introduced in #124 

## Technical solution after this PR

- A default query has been integrated to automatically fetch validation results from Dynatrace.
- Each entry in the validation results table now includes a direct link that opens the Site Reliability Guardian (SRG) view.

![image](https://github.com/Dynatrace/backstage-plugin/assets/119623079/741387e6-a16b-427f-a35d-b1628f7386a8)

- When there are no validation results to display, an empty screen will now appear promoting the Site Reliability Guardian.

![image](https://github.com/Dynatrace/backstage-plugin/assets/119623079/f4dc2afa-45c1-46a9-9bfb-60e95bddf409)


#### :heavy_check_mark: Common checklist

- [x] Added tests for new functionality and regression tests for bug fixes
- [x] Screenshots of before and after attached (for UI changes)
- [x] Added or updated documentation (if applicable)
- [x] Helpful resources linked (if applicable)
