### PR TITLE
chore: change HTTP_PROXY tO HTTPS_PROXY

### DIFF
--- a/plugins/dql-backend/README.md
+++ b/plugins/dql-backend/README.md
@@ -14,6 +14,10 @@ on [localhost:7007/dql](http://localhost:7007/dql).
 
 ## Behind a corporate proxy
 
-If your application is behind a corporate proxy, set `HTTP_PROXY` as an
+If your application is behind a corporate proxy, set `HTTPS_PROXY` as an
 environment variable. This will be passed to `HttpsProxyAgent` as `agent` in the
 fetch request.
+
+There is another method, you can open firewall for Dynatrace tokenUrl
+https://sso.dynatrace.com and https://xxxxxxxx.apps.dynatrace.com. In that case,
+you don't need HTTPS_PROXY.

--- a/plugins/dql-backend/src/utils/dtFetch.ts
+++ b/plugins/dql-backend/src/utils/dtFetch.ts
@@ -19,8 +19,8 @@ import { HttpsProxyAgent } from 'https-proxy-agent';
 import fetch, { RequestInfo, RequestInit, Response } from 'node-fetch';
 
 const userAgent: string = getUserAgent();
-const agent = process.env.HTTP_PROXY
-  ? new HttpsProxyAgent(process.env.HTTP_PROXY)
+const agent = process.env.HTTPS_PROXY
+  ? new HttpsProxyAgent(process.env.HTTPS_PROXY)
   : undefined;
 
 export const dtFetch = (


### PR DESCRIPTION
# Introduction

HTTP_PROXY proxy doesn't work. dynatrace require HTTPS_PROXY.

## Technical solution before this PR

HTTP_PROXY does not work. HTTPS_PROXY works fine.

## Technical solution after this PR


#### :heavy_check_mark: Common checklist

- [ ] Added tests for new functionality and regression tests for bug fixes
- [ ] Screenshots of before and after attached (for UI changes)
- [ ] Added or updated documentation (if applicable)
- [ ] Helpful resources linked (if applicable)
