### PR TITLE
feat: support more table data types

### DIFF
--- a/README.md
+++ b/README.md
@@ -317,16 +317,10 @@ following in your query:
 filter backstageComponent == "$${componentNamespace}.$${componentName}"
 ```
 
-To be able to render correctly, the DQL must return data conforming to the
-following:
+To be able to render correctly, the DQL must return an array. Links are also
+supported and can be added to the table if transformed like this:
 
-- No `null` values; use `coalesce` to replace `null` values with a default value
-- May contain simple types:
-  - Strings (e.g. `Name: 'My Name'`)
-- May contain complex types that have a type discriminator (`type`):
-  - Links: (e.g.
-    `Logs: { type: 'link', title: 'Link to Logs', url: 'https...' }`)
-- As a fallback, other types will be rendered as JSON
+`Logs: { type: 'link', title: 'Link to Logs', url: 'https...' }`
 
 An example of a valid DQL result would be:
 
@@ -335,10 +329,18 @@ An example of a valid DQL result would be:
   {
     "Name": "backstage",
     "Namespace": "hardening",
+    "LogCount": 0,
+    "latestLog": null,
+    "hasLogs": false,
     "Link": {
       "type": "link",
       "text": "Click me",
       "url": "https://backstage.io"
+    },
+    "metadata": {
+      "time": {
+        "timestamp": "xyz"
+      }
     }
   }
 ]

--- a/plugins/dql-backend/src/service/dynatraceApi.test.ts
+++ b/plugins/dql-backend/src/service/dynatraceApi.test.ts
@@ -162,6 +162,18 @@ describe('dynatraceApi', () => {
     );
   });
 
+  it('should remove trailing slashes for the URL', () => {
+    // arrange
+    const dynatraceApi = new DynatraceApi(
+      { ...defaultApiConfig, url: 'https://example.com/' },
+      'identifier',
+      logger,
+    );
+
+    // assert
+    expect(dynatraceApi.environmentUrl).toBe('https://example.com');
+  });
+
   describe('getAccessToken', () => {
     it('should throw an error if the token request failed', async () => {
       // arrange

--- a/plugins/dql-backend/src/service/dynatraceApi.ts
+++ b/plugins/dql-backend/src/service/dynatraceApi.ts
@@ -152,11 +152,19 @@ const getAccessToken = async (
 };
 
 export class DynatraceApi {
+  private readonly config: DynatraceEnvironmentConfig;
   constructor(
-    private readonly config: DynatraceEnvironmentConfig,
+    config: DynatraceEnvironmentConfig,
     private identifier: string,
     private logger: LoggerService,
-  ) {}
+  ) {
+    this.config = {
+      ...config,
+      url: config.url.endsWith('/')
+        ? config.url.substring(0, config.url.length - 1)
+        : config.url,
+    };
+  }
 
   get environmentName() {
     return this.config.name;

--- a/plugins/dql/dev/data.ts
+++ b/plugins/dql/dev/data.ts
@@ -13,14 +13,17 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { TabularData } from '@dynatrace/backstage-plugin-dql-common';
+import {
+  TableTypes,
+  TabularData,
+} from '@dynatrace/backstage-plugin-dql-common';
 
 export const exampleData: TabularData = [
   {
     Name: 'backstage',
     Namespace: 'hardening',
     'A Link': {
-      type: 'link',
+      type: TableTypes.LINK,
       text: 'https://backstage.io',
       url: 'https://backstage.io',
     },
@@ -29,7 +32,7 @@ export const exampleData: TabularData = [
     Name: 'nginx',
     Namespace: 'default',
     'A Link': {
-      type: 'link',
+      type: TableTypes.LINK,
       text: 'https://nginx.org',
       url: 'https://nginx.org',
     },

--- a/plugins/dql/src/components/ObjectModal.test.tsx
+++ b/plugins/dql/src/components/ObjectModal.test.tsx
@@ -1,0 +1,63 @@
+/**
+ * @license
+ * Copyright 2024 Dynatrace LLC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { ObjectModalProps, ObjectModal } from './ObjectModal';
+import { renderInTestApp } from '@backstage/test-utils';
+import { screen } from '@testing-library/react';
+import { userEvent } from '@testing-library/user-event';
+import React from 'react';
+
+const prepareComponent = async ({
+  data = '{}',
+  property = 'my prop',
+}: Partial<ObjectModalProps> = {}) => {
+  return await renderInTestApp(<ObjectModal data={data} property={property} />);
+};
+
+const getOpenModalButton = () =>
+  screen.getByRole('button', { name: 'Complex record' });
+const getCloseModalButton = () => screen.getByRole('button', { name: 'close' });
+
+describe('ObjectModal', () => {
+  it('should open the modal with JSON data', async () => {
+    // arrange
+    await prepareComponent({
+      data: JSON.stringify({ myProperty: 'My value' }),
+    });
+
+    // act
+    await userEvent.click(getOpenModalButton());
+
+    // assert
+    expect(screen.getByRole('dialog')).toBeVisible();
+    expect(screen.getByRole('dialog')).toHaveTextContent(
+      '"myProperty":"My value"',
+    );
+  });
+
+  it('should close the modal on close button click', async () => {
+    // arrange
+    await prepareComponent({
+      data: JSON.stringify({ myProperty: 'My value' }),
+    });
+
+    // act
+    await userEvent.click(getOpenModalButton());
+    await userEvent.click(getCloseModalButton());
+
+    // assert
+    expect(screen.queryByRole('dialog')).not.toBeVisible();
+  });
+});

--- a/plugins/dql/src/components/ObjectModal.tsx
+++ b/plugins/dql/src/components/ObjectModal.tsx
@@ -1,0 +1,113 @@
+/**
+ * @license
+ * Copyright 2024 Dynatrace LLC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { CodeSnippet } from '@backstage/core-components';
+import {
+  createStyles,
+  Dialog,
+  DialogContent,
+  DialogTitle as MuiDialogTitle,
+  IconButton,
+  Link,
+  Theme,
+  Typography,
+  withStyles,
+  WithStyles,
+} from '@material-ui/core';
+import CloseIcon from '@material-ui/icons/Close';
+import React, { useState } from 'react';
+
+export type ObjectModalProps = {
+  data: string;
+  property: string;
+};
+
+const styles = (theme: Theme) =>
+  createStyles({
+    root: {
+      margin: 0,
+      padding: theme.spacing(2),
+    },
+    flex: {
+      display: 'flex',
+      flexDirection: 'row',
+      alignItems: 'center',
+      justifyContent: 'space-between',
+      gap: theme.spacing(2),
+    },
+    closeButton: {
+      color: theme.palette.grey[500],
+    },
+  });
+
+export interface DialogTitleProps extends WithStyles<typeof styles> {
+  id: string;
+  children: React.ReactNode;
+  onClose: () => void;
+}
+const DialogTitle = withStyles(styles)((props: DialogTitleProps) => {
+  const { children, classes, onClose, ...other } = props;
+  return (
+    <MuiDialogTitle disableTypography className={classes.root} {...other}>
+      <div className={classes.flex}>
+        <Typography variant="h6">{children}</Typography>
+        <IconButton
+          aria-label="close"
+          className={classes.closeButton}
+          onClick={() => onClose()}
+        >
+          <CloseIcon />
+        </IconButton>
+      </div>
+    </MuiDialogTitle>
+  );
+});
+
+export const ObjectModal = ({ data, property }: ObjectModalProps) => {
+  const [isOpen, setIsOpen] = useState(false);
+
+  const onComplexRecordClick = () => {
+    setIsOpen(true);
+  };
+
+  const onModalClose = () => {
+    setIsOpen(false);
+  };
+
+  return (
+    <>
+      <Link
+        component="button"
+        variant="body2"
+        onClick={() => onComplexRecordClick()}
+        style={{ minWidth: '120px' }}
+      >
+        Complex record
+      </Link>
+      <Dialog
+        open={isOpen}
+        onClose={() => onModalClose()}
+        aria-labelledby={'object-dialog-title'}
+      >
+        <DialogTitle id="object-dialog-title" onClose={onModalClose}>
+          Complex record of "{property}"
+        </DialogTitle>
+        <DialogContent dividers>
+          <CodeSnippet text={data} language={'json'} />
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+};

--- a/plugins/dql/src/components/TabularDataTable.test.tsx
+++ b/plugins/dql/src/components/TabularDataTable.test.tsx
@@ -14,7 +14,10 @@
  * limitations under the License.
  */
 import { TabularDataTable } from './TabularDataTable';
-import { TabularData } from '@dynatrace/backstage-plugin-dql-common';
+import {
+  TableTypes,
+  TabularData,
+} from '@dynatrace/backstage-plugin-dql-common';
 import { fireEvent, render, waitFor } from '@testing-library/react';
 import React from 'react';
 
@@ -61,7 +64,7 @@ describe('TabularDataTable', () => {
     const data: TabularData = [
       {
         Header: {
-          type: 'link',
+          type: TableTypes.LINK,
           text: 'value',
           url: href,
         },


### PR DESCRIPTION
# Introduction

Extends the supported data types for the DQL table. Now everything that's in an array should be supported (nulll, boolean, number, object).
![image](https://github.com/user-attachments/assets/46c2b4dd-e455-4495-88e3-055d0f6e351e)

resolves https://github.com/Dynatrace/backstage-plugin/issues/152

## Technical solution before this PR

The table only allowed strings

## Technical solution after this PR
The table should now support every returned array.

#### :heavy_check_mark: Common checklist

- [x] Added tests for new functionality and regression tests for bug fixes
- [x] Screenshots of before and after attached (for UI changes)
- [x] Added or updated documentation (if applicable)
