### PR TITLE
chore: align versions with published plugin versions

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
   "packages": ["packages/*", "plugins/*"],
   "npmClient": "yarn",
-  "version": "0.1.1"
+  "version": "2.1.5"
 }

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "app",
-  "version": "0.0.0",
+  "version": "2.1.5",
   "private": true,
   "bundled": true,
   "repository": {
@@ -44,7 +44,7 @@
     "@backstage/plugin-techdocs-react": "^1.2.9",
     "@backstage/plugin-user-settings": "^0.8.14",
     "@backstage/theme": "^0.6.0",
-    "@dynatrace/backstage-plugin-dql": "^0.1.0",
+    "@dynatrace/backstage-plugin-dql": "^2.1.5",
     "@material-ui/core": "^4.12.2",
     "@material-ui/icons": "^4.9.1",
     "history": "^5.0.0",

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backend",
-  "version": "0.0.0",
+  "version": "2.1.5",
   "main": "dist/index.cjs.js",
   "types": "src/index.ts",
   "private": true,
@@ -42,7 +42,7 @@
     "@backstage/plugin-search-backend-module-pg": "^0.5.37",
     "@backstage/plugin-search-backend-node": "^1.3.4",
     "@backstage/plugin-techdocs-backend": "^1.11.1",
-    "@dynatrace/backstage-plugin-dql-backend": "^0.1.0",
+    "@dynatrace/backstage-plugin-dql-backend": "^2.1.5",
     "app": "link:../app",
     "dockerode": "^4.0.0",
     "express": "^4.17.1",

--- a/plugins/dql-backend/package.json
+++ b/plugins/dql-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dynatrace/backstage-plugin-dql-backend",
-  "version": "0.1.0",
+  "version": "2.1.5",
   "license": "Apache-2.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
@@ -35,7 +35,7 @@
   },
   "dependencies": {
     "@backstage/config": "^1.2.0",
-    "@dynatrace/backstage-plugin-dql-common": "^0.1.0",
+    "@dynatrace/backstage-plugin-dql-common": "^2.1.5",
     "@types/express": "*",
     "express": "^4.17.1",
     "express-promise-router": "^4.1.0",

--- a/plugins/dql-common/package.json
+++ b/plugins/dql-common/package.json
@@ -2,7 +2,7 @@
   "name": "@dynatrace/backstage-plugin-dql-common",
   "description": "Common functionalities for the Dynatrace DQL plugin",
   "license": "Apache-2.0",
-  "version": "0.1.0",
+  "version": "2.1.5",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "publishConfig": {

--- a/plugins/dql/package.json
+++ b/plugins/dql/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dynatrace/backstage-plugin-dql",
-  "version": "0.1.0",
+  "version": "2.1.5",
   "license": "Apache-2.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
@@ -40,7 +40,7 @@
     "@backstage/errors": "^1.2.4",
     "@backstage/plugin-catalog-react": "^1.14.0",
     "@backstage/theme": "^0.6.0",
-    "@dynatrace/backstage-plugin-dql-common": "^0.1.0",
+    "@dynatrace/backstage-plugin-dql-common": "^2.1.5",
     "@material-ui/core": "^4.12.2",
     "@material-ui/icons": "^4.9.1",
     "@material-ui/lab": "4.0.0-alpha.61",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7760,14 +7760,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@dynatrace/backstage-plugin-dql-backend@npm:^0.1.0, @dynatrace/backstage-plugin-dql-backend@workspace:plugins/dql-backend":
+"@dynatrace/backstage-plugin-dql-backend@npm:^2.1.5, @dynatrace/backstage-plugin-dql-backend@workspace:plugins/dql-backend":
   version: 0.0.0-use.local
   resolution: "@dynatrace/backstage-plugin-dql-backend@workspace:plugins/dql-backend"
   dependencies:
     "@backstage/cli": "npm:^0.28.2"
     "@backstage/config": "npm:^1.2.0"
     "@backstage/test-utils": "npm:^1.7.0"
-    "@dynatrace/backstage-plugin-dql-common": "npm:^0.1.0"
+    "@dynatrace/backstage-plugin-dql-common": "npm:^2.1.5"
     "@types/express": "npm:*"
     "@types/supertest": "npm:^6.0.0"
     express: "npm:^4.17.1"
@@ -7781,7 +7781,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@dynatrace/backstage-plugin-dql-common@npm:^0.1.0, @dynatrace/backstage-plugin-dql-common@workspace:plugins/dql-common":
+"@dynatrace/backstage-plugin-dql-common@npm:^2.1.5, @dynatrace/backstage-plugin-dql-common@workspace:plugins/dql-common":
   version: 0.0.0-use.local
   resolution: "@dynatrace/backstage-plugin-dql-common@workspace:plugins/dql-common"
   dependencies:
@@ -7792,7 +7792,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@dynatrace/backstage-plugin-dql@npm:^0.1.0, @dynatrace/backstage-plugin-dql@workspace:plugins/dql":
+"@dynatrace/backstage-plugin-dql@npm:^2.1.5, @dynatrace/backstage-plugin-dql@workspace:plugins/dql":
   version: 0.0.0-use.local
   resolution: "@dynatrace/backstage-plugin-dql@workspace:plugins/dql"
   dependencies:
@@ -7806,7 +7806,7 @@ __metadata:
     "@backstage/plugin-catalog-react": "npm:^1.14.0"
     "@backstage/test-utils": "npm:^1.7.0"
     "@backstage/theme": "npm:^0.6.0"
-    "@dynatrace/backstage-plugin-dql-common": "npm:^0.1.0"
+    "@dynatrace/backstage-plugin-dql-common": "npm:^2.1.5"
     "@material-ui/core": "npm:^4.12.2"
     "@material-ui/icons": "npm:^4.9.1"
     "@material-ui/lab": "npm:4.0.0-alpha.61"
@@ -17089,7 +17089,7 @@ __metadata:
     "@backstage/plugin-user-settings": "npm:^0.8.14"
     "@backstage/test-utils": "npm:^1.7.0"
     "@backstage/theme": "npm:^0.6.0"
-    "@dynatrace/backstage-plugin-dql": "npm:^0.1.0"
+    "@dynatrace/backstage-plugin-dql": "npm:^2.1.5"
     "@material-ui/core": "npm:^4.12.2"
     "@material-ui/icons": "npm:^4.9.1"
     "@testing-library/dom": "npm:^8.0.0"
@@ -17898,7 +17898,7 @@ __metadata:
     "@backstage/plugin-search-backend-module-pg": "npm:^0.5.37"
     "@backstage/plugin-search-backend-node": "npm:^1.3.4"
     "@backstage/plugin-techdocs-backend": "npm:^1.11.1"
-    "@dynatrace/backstage-plugin-dql-backend": "npm:^0.1.0"
+    "@dynatrace/backstage-plugin-dql-backend": "npm:^2.1.5"
     "@types/dockerode": "npm:^3.3.0"
     "@types/express": "npm:^4.17.6"
     "@types/express-serve-static-core": "npm:^4.17.5"


### PR DESCRIPTION
This PR contains: 

- the alignment of versions in package.json files with version of our published plugins
    - FYI: changes done by executing `npx lerna version 2.5.1 --yes --no-git-tag-version --no-push` 
