### PR TITLE
fix(configschema): change environments from tuple to array for multi …

### DIFF
--- a/plugins/dql-backend/config.d.ts
+++ b/plugins/dql-backend/config.d.ts
@@ -16,7 +16,7 @@
 
 export type Config = {
   dynatrace: {
-    environments: [
+    environments: 
       {
         /**
          * @visibility frontend
@@ -42,8 +42,7 @@ export type Config = {
          * @visibility backend
          */
         tokenUrl?: string;
-      },
-    ];
+      }[],
 
     queries?: {
       [queryId: string]: string;


### PR DESCRIPTION
…env support

# Introduction

This pr is to enable correct type for environment, which is suppose to be an array of zero or more environments, logically at least one but this can not be forced.

Even though the current implementation works with multiple environments, this PR will fix:

- warnings about faulty configs in Backstage
- exposing secrets in Backstage developer tools with multiple environments

## Technical solution before this PR

Environments were defined as single tuple in configSchema

## Technical solution after this PR

configSchema is now updated to accept array of zero or more environments

TypeScript type documentation: https://www.typescriptlang.org/docs/handbook/basic-types.html#array

#### :heavy_check_mark: Common checklist

- [] Added tests for new functionality and regression tests for bug fixes
- [] Screenshots of before and after attached (for UI changes)
- [] Added or updated documentation (if applicable)
- [x] Helpful resources linked (if applicable)

Fixes #188
