### PR TITLE
feat: Add release version in k8s overview

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,6 +225,11 @@ here:
 [`dynatrace.kubernetes-deployments`](plugins/dql-backend/src/service/queries.ts).
 You can change this query for all cards or override it using a custom query.
 
+_Convention:_ To display the pod's version in Backstage, annotate it using the following key-value pair:
+```yaml
+app.kubernetes.io/version: <version>
+```
+
 ### Site Reliability Guardian Validations
 
 Using the `EntityDqlQueryCard` with the queryId `dynatrace.srg-validations`, you

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -6,7 +6,6 @@ metadata:
   annotations:
     backstage.io/kubernetes-id: kubernetescustom
     dynatrace.com/guardian-tags: "service=my-service,stage=development,novalue"
-    app.kubernetes.io/version: "1"
   dynatrace:
     queries:
       - id: Error Logs

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -6,6 +6,7 @@ metadata:
   annotations:
     backstage.io/kubernetes-id: kubernetescustom
     dynatrace.com/guardian-tags: "service=my-service,stage=development,novalue"
+    app.kubernetes.io/version: "1"
   dynatrace:
     queries:
       - id: Error Logs

--- a/plugins/dql-backend/src/service/queries.test.ts
+++ b/plugins/dql-backend/src/service/queries.test.ts
@@ -102,7 +102,6 @@ describe('queries', () => {
         getEntity({
           'backstage.io/kubernetes-label-selector': 'label=value',
           'backstage.io/kubernetes-namespace': 'namespace',
-          'app.kubernetes.io/version': '1.0.1',
         }),
         defaultApiConfig,
       );

--- a/plugins/dql-backend/src/service/queries.test.ts
+++ b/plugins/dql-backend/src/service/queries.test.ts
@@ -95,6 +95,21 @@ describe('queries', () => {
       // assert
       expect(query).toContain('| filter workload.labels[`label`] == "value"');
     });
+
+     it('should return the query with the version column included', () => {
+      // act
+      const query = dynatraceQueries[DynatraceQueryKeys.KUBERNETES_DEPLOYMENTS](
+        getEntity({
+          'backstage.io/kubernetes-label-selector': 'label=value',
+          'backstage.io/kubernetes-namespace': 'namespace',
+          'app.kubernetes.io/version': '1.0.1',
+        }),
+        defaultApiConfig,
+      );
+
+      // assert
+      expect(query).toContain('| fieldsAdd Version = "1.0.1"');
+    });
   });
   describe(DynatraceQueryKeys.SRG_VALIDATIONS, () => {
     it('should return the srg-query', () => {

--- a/plugins/dql-backend/src/service/queries.test.ts
+++ b/plugins/dql-backend/src/service/queries.test.ts
@@ -108,7 +108,7 @@ describe('queries', () => {
       );
 
       // assert
-      expect(query).toContain('| fieldsAdd Version = "1.0.1"');
+      expect(query).toContain('| fieldsAdd Version = coalesce(workload.labels[`app.kubernetes.io/version`], "")');
     });
   });
   describe(DynatraceQueryKeys.SRG_VALIDATIONS, () => {

--- a/plugins/dql-backend/src/service/queries.ts
+++ b/plugins/dql-backend/src/service/queries.ts
@@ -65,6 +65,8 @@ export const dynatraceQueries: Record<
       entity.metadata.annotations?.['backstage.io/kubernetes-id'];
     const namespace =
       entity.metadata.annotations?.['backstage.io/kubernetes-namespace'];
+    const version =
+      entity.metadata.annotations?.['app.kubernetes.io/version'];
 
     const filterLabel = labelSelector
       ? generateKubernetesSelectorFilter(labelSelector)
@@ -76,6 +78,10 @@ export const dynatraceQueries: Record<
         : `| filter workload.labels[\`backstage.io/kubernetes-id\`] == "${kubernetesId}"`;
     const filterNamespace = namespace
       ? `| filter Namespace == "${namespace}"`
+      : '';
+    
+    const fieldVersion = version 
+      ? `| fieldsAdd Version = "${version}"`
       : '';
 
     if (!filterKubernetesId && !filterLabel) {
@@ -111,7 +117,8 @@ export const dynatraceQueries: Record<
       apiConfig,
     )}})
     | fieldsRemove id, name, workload.labels, cluster.id, namespace.id
-    | fieldsAdd Environment = "${apiConfig.environmentName}"`;
+    | fieldsAdd Environment = "${apiConfig.environmentName}"
+    ${fieldVersion}`;
   },
   [DynatraceQueryKeys.SRG_VALIDATIONS]: (entity, apiConfig) => {
     const catalogTags =

--- a/plugins/dql-backend/src/service/queries.ts
+++ b/plugins/dql-backend/src/service/queries.ts
@@ -65,8 +65,6 @@ export const dynatraceQueries: Record<
       entity.metadata.annotations?.['backstage.io/kubernetes-id'];
     const namespace =
       entity.metadata.annotations?.['backstage.io/kubernetes-namespace'];
-    const version =
-      entity.metadata.annotations?.['app.kubernetes.io/version'];
 
     const filterLabel = labelSelector
       ? generateKubernetesSelectorFilter(labelSelector)
@@ -78,10 +76,6 @@ export const dynatraceQueries: Record<
         : `| filter workload.labels[\`backstage.io/kubernetes-id\`] == "${kubernetesId}"`;
     const filterNamespace = namespace
       ? `| filter Namespace == "${namespace}"`
-      : '';
-    
-    const fieldVersion = version 
-      ? `| fieldsAdd Version = "${version}"`
       : '';
 
     if (!filterKubernetesId && !filterLabel) {
@@ -116,9 +110,9 @@ export const dynatraceQueries: Record<
       'id',
       apiConfig,
     )}})
-    | fieldsRemove id, name, workload.labels, cluster.id, namespace.id
     | fieldsAdd Environment = "${apiConfig.environmentName}"
-    ${fieldVersion}`;
+    | fieldsAdd Version = coalesce(workload.labels[\`app.kubernetes.io/version\`], "")
+    | fieldsRemove id, name, workload.labels, cluster.id, namespace.id`;
   },
   [DynatraceQueryKeys.SRG_VALIDATIONS]: (entity, apiConfig) => {
     const catalogTags =


### PR DESCRIPTION
# Introduction

Closes https://github.com/Dynatrace/backstage-plugin/issues/194

## Technical solution before this PR

When developing a component it would be great to see which version of that component is currently deployed in which namespaces / cluster. The Kubernetes Tile is missing the information about the version.

## Technical solution after this PR

The version is picked from the annotation `app.kubernetes.io/version` defined in the deployment descriptor of the pod and displayed in the field `Version`.
<img width="1451" height="798" alt="image" src="https://github.com/user-attachments/assets/11f77697-a79f-404b-b116-02caae7590c6" />


#### :heavy_check_mark: Common checklist

- [x] Added tests for new functionality and regression tests for bug fixes
- [x] Screenshots of before and after attached (for UI changes)
- [x] Added or updated documentation (if applicable)
- [ ] Helpful resources linked (if applicable)
