### PR TITLE
feat: Add DQL execution logging based on .env

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,10 @@ details.
 Find here additional features to customize the plugin for different
 requirements.
 
+### DQL Query logs
+
+Setup ```LOG_QUERY=true``` node env variable to be able to log DQL queries during execution 
+
 ### Multi-environment Support
 
 If the component in Backstage should display data from multiple Dynatrace

--- a/plugins/dql-backend/src/service/dynatraceApi.test.ts
+++ b/plugins/dql-backend/src/service/dynatraceApi.test.ts
@@ -266,6 +266,12 @@ describe('dynatraceApi', () => {
   });
 
   describe('logger', () => {
+    let oldEnv: NodeJS.ProcessEnv;
+
+    afterAll(() => {
+      process.env = oldEnv;
+    });
+
     beforeEach(() => {
       mockTokenResult({
         json: {
@@ -280,6 +286,9 @@ describe('dynatraceApi', () => {
         json: { state: 'RUNNING', requestToken: 'myToken', ttlSeconds: 200 },
       });
       mockPollResult({ ok: false, text: '400: Invalid token' });
+
+      oldEnv = process.env;
+      process.env = { ...process.env, LOG_QUERY: 'true' };
     });
 
     it('should show logs', async () => {

--- a/plugins/dql-backend/src/service/dynatraceApi.ts
+++ b/plugins/dql-backend/src/service/dynatraceApi.ts
@@ -186,6 +186,10 @@ export class DynatraceApi {
       identifier: this.identifier,
     };
 
+    if (process.env.LOG_QUERY) {
+      this.logger.info(`Executing DQL query: ${query}`);
+    }
+
     const execQueryRes = await executeQuery(environment, query);
     return await waitForQueryResult(
       environment,


### PR DESCRIPTION
# Introduction

Add DQL execution logging based on .env

## Technical solution before this PR

User should be able to log the executed DQL query

## Technical solution after this PR

Add .env LOG_QUERY that allows to log every DQL query on execution.

#### :heavy_check_mark: Common checklist

- [x] Added tests for new functionality and regression tests for bug fixes
