### PR TITLE
feat: Include SDLC guardian validations

### DIFF
--- a/plugins/dql-backend/src/service/queries.test.ts
+++ b/plugins/dql-backend/src/service/queries.test.ts
@@ -119,6 +119,9 @@ describe('queries', () => {
       );
 
       // assert
+      
+      expect(query).toContain('fetch events');
+      expect(query).toContain('| filter event.kind == "SDLC_EVENT" AND event.type == "validation"');
       expect(query).toContain('fetch bizevents');
       expect(query).toContain(
         '| filter event.provider == "dynatrace.site.reliability.guardian"',
@@ -135,9 +138,11 @@ describe('queries', () => {
       );
 
       // assert
+      expect(query).toContain('fetch events');
+      expect(query).toContain('| filter event.kind == "SDLC_EVENT" AND event.type == "validation"');
       expect(query).toContain('fetch bizevents');
-      expect(query).toContain('isNotNull(tags[novalue])');
-      expect(query).toContain('in (tags[`service`], "my-service")');
+      expect(query.match(/isNotNull\(tags\[novalue\]\)/g)?.length).toBe(2);
+      expect(query.match(/in \(tags\[`service`\], "my-service"\)/g)?.length).toBe(2);
       expect(query).toContain(
         '| filter event.provider == "dynatrace.site.reliability.guardian"',
       );


### PR DESCRIPTION
# Introduction

As of the latest version, the Site Reliability Guardian now supports validation of `SDLC` events through Lifecycle Guardians.

https://docs.dynatrace.com/docs/discover-dynatrace/references/semantic-dictionary/model/sdlc-events
https://docs.dynatrace.com/docs/whats-new/saas/sprint-324#site-reliability-guardian-supports-sdlc-events-for-streamlined-software-lifecycle-insights

## Technical solution before this PR

Previously, the Site Reliability Guardian Validations Table only displayed guardians validations based on `bizevents` (business events).

## Technical solution after this PR

The query used to retrieve guardian validations has been updated to include SDLC-guardian-based validations. While the underlying data has expanded, the table layout remains unchanged.

<img width="3135" height="808" alt="image" src="https://github.com/user-attachments/assets/fbf5e434-cdf9-4382-b20f-1cc44b9a20f5" />


#### :heavy_check_mark: Common checklist

- [x] Added tests for new functionality and regression tests for bug fixes
- [x] Screenshots of before and after attached (for UI changes)
- [x] Added or updated documentation (if applicable)
- [x] Helpful resources linked (if applicable)
