### PR TITLE
chore: clean up app-config

### DIFF
--- a/app-config.yaml
+++ b/app-config.yaml
@@ -19,10 +19,6 @@ backend:
 techdocs:
   builder: local
 
-auth:
-  providers:
-    guest: {}
-
 catalog:
   rules:
     - allow: [Component, System, API, Resource, Location, User, Group]


### PR DESCRIPTION
This pull request makes a small configuration change to the `app-config.yaml` file by removing the guest authentication provider as this should be only used for development (for reference read [here](https://backstage.io/docs/auth/guest/provider/#summary)).