### PR TITLE
chore: upgrade node-forge and handlebars

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -22668,8 +22668,8 @@ __metadata:
   linkType: hard
 
 "handlebars@npm:^4.7.3, handlebars@npm:^4.7.7":
-  version: 4.7.8
-  resolution: "handlebars@npm:4.7.8"
+  version: 4.7.9
+  resolution: "handlebars@npm:4.7.9"
   dependencies:
     minimist: "npm:^1.2.5"
     neo-async: "npm:^2.6.2"
@@ -22681,7 +22681,7 @@ __metadata:
       optional: true
   bin:
     handlebars: bin/handlebars
-  checksum: 10c0/7aff423ea38a14bb379316f3857fe0df3c5d66119270944247f155ba1f08e07a92b340c58edaa00cfe985c21508870ee5183e0634dcb53dd405f35c93ef7f10d
+  checksum: 10c0/22f8105a7e68e81aff2662bb434edf05f757d21d850731d71cec886d69c10cd33d3c43e34b2892968ec62de8241611851d3d0674c8ef324ea3e01dc66262faa9
   languageName: node
   linkType: hard
 
@@ -28568,9 +28568,9 @@ __metadata:
   linkType: hard
 
 "node-forge@npm:^1, node-forge@npm:^1.2.1, node-forge@npm:^1.3.1, node-forge@npm:^1.3.2":
-  version: 1.3.3
-  resolution: "node-forge@npm:1.3.3"
-  checksum: 10c0/9c6f53b0ebb34865872cf62a35b0aef8fb337e2efc766626c2e3a0040f4c02933bf29a62ba999eb44a2aca73bd512c4eda22705a47b94654b9fb8ed53db9a1db
+  version: 1.4.0
+  resolution: "node-forge@npm:1.4.0"
+  checksum: 10c0/67330a5f1f95257a4c8a93b7d555abe87b5f15e350123aa396c97a21a8ca94f9c6549008eb2c73668a91e0d7e3a905785acbd8f8bd0751c29401292011f8f8e1
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Security: Upgrade node-forge and handlebars to fix CVEs

Upgrades two transitive dependencies in `yarn.lock` to resolve high/critical severity vulnerabilities. No overrides were needed as all dependents' semver ranges are compatible with the new versions.

### node-forge `1.3.3` → `1.4.0`
- **CVE-2026-33891** – DoS via infinite loop in `BigInteger.modInverse()`
- **CVE-2026-33894** – RSA-PKCS signature forgery via ASN.1 extra field
- **CVE-2026-33895** – Ed25519 signature forgery (missing `S > L` check)
- **CVE-2026-33896** – `basicConstraints` bypass in certificate chain verification

### handlebars `4.7.8` → `4.7.9`
- **CVE-2026-33937** – RCE via JavaScript injection through AST type confusion
- **CVE-2026-33938** – RCE via JavaScript injection through `@partial-block` AST tampering
- **CVE-2026-33939** – DoS via malformed decorator syntax
- **CVE-2026-33940** – RCE via crafted object passed as dynamic partial
- **CVE-2026-33941** – JavaScript injection in CLI precompiler via unescaped names/options
