### PR TITLE
feat: Improve entity resolution flow with request-scoped credentials and refactor auth handling

### DIFF
--- a/plugins/dql-backend/src/utils/routeUtils.test.ts
+++ b/plugins/dql-backend/src/utils/routeUtils.test.ts
@@ -35,11 +35,13 @@ describe('routeUtils', () => {
   } as unknown as CatalogClient;
 
   const getPluginRequestTokenMock: jest.Mock<
-    Awaited<ReturnType<AuthService['getPluginRequestToken']>>
+    ReturnType<AuthService['getPluginRequestToken']>,
+    Parameters<AuthService['getPluginRequestToken']>
   > = jest.fn().mockResolvedValue({ token: 'mock-token' });
 
   const getOwnServiceCredentialsMock: jest.Mock<
-    Awaited<ReturnType<AuthService['getOwnServiceCredentials']>>
+    ReturnType<AuthService['getOwnServiceCredentials']>,
+    Parameters<AuthService['getOwnServiceCredentials']>
   > = jest.fn();
   const mockedAuth = {
     getPluginRequestToken: getPluginRequestTokenMock,
@@ -96,6 +98,28 @@ describe('routeUtils', () => {
           name: 'myComp',
         },
       });
+    });
+
+    it('should not use own service credentials for user-controlled entityRef resolution', async () => {
+      const serviceCredentials = {
+        subject: 'plugin:dynatrace-dql',
+      } as unknown as Awaited<
+        ReturnType<AuthService['getOwnServiceCredentials']>
+      >;
+      getOwnServiceCredentialsMock.mockResolvedValue(serviceCredentials);
+
+      await getEntityFromRequest(
+        getRequest(mockedEntityRef),
+        mockedClient,
+        mockedAuth,
+      );
+
+      expect(getPluginRequestTokenMock).not.toHaveBeenCalledWith(
+        expect.objectContaining({
+          onBehalfOf: serviceCredentials,
+          targetPluginId: 'catalog',
+        }),
+      );
     });
   });
 

--- a/plugins/dql-backend/src/utils/routeUtils.test.ts
+++ b/plugins/dql-backend/src/utils/routeUtils.test.ts
@@ -22,9 +22,17 @@ import { Request } from 'express';
 
 const mockedEntityRef = 'component:default/example';
 
+const defaultNoneCredentials = {
+  $$type: '@backstage/BackstageCredentials',
+  principal: { type: 'none' },
+} as unknown as Awaited<ReturnType<AuthService['getNoneCredentials']>>;
+
 describe('routeUtils', () => {
-  const getRequest = (ref: string) => {
-    return { query: { entityRef: ref } } as unknown as Request;
+  const getRequest = (ref: string, authorizationHeader?: string) => {
+    return {
+      query: { entityRef: ref },
+      headers: authorizationHeader ? { authorization: authorizationHeader } : {},
+    } as unknown as Request;
   };
   const getEntityByRefMock: jest.Mock<
     ReturnType<CatalogApi['getEntityByRef']>,
@@ -43,13 +51,29 @@ describe('routeUtils', () => {
     ReturnType<AuthService['getOwnServiceCredentials']>,
     Parameters<AuthService['getOwnServiceCredentials']>
   > = jest.fn();
+
+  const authenticateMock: jest.Mock<
+    ReturnType<AuthService['authenticate']>,
+    Parameters<AuthService['authenticate']>
+  > = jest.fn();
+
+  const getNoneCredentialsMock: jest.Mock<
+    ReturnType<AuthService['getNoneCredentials']>,
+    Parameters<AuthService['getNoneCredentials']>
+  > = jest.fn();
+
   const mockedAuth = {
     getPluginRequestToken: getPluginRequestTokenMock,
     getOwnServiceCredentials: getOwnServiceCredentialsMock,
+    authenticate: authenticateMock,
+    getNoneCredentials: getNoneCredentialsMock,
   } as unknown as AuthService;
 
   beforeEach(() => {
     getEntityByRefMock.mockReset();
+    authenticateMock.mockReset();
+    getNoneCredentialsMock.mockReset();
+    getNoneCredentialsMock.mockResolvedValue(defaultNoneCredentials);
 
     getEntityByRefMock.mockResolvedValue({
       kind: 'component',
@@ -120,6 +144,41 @@ describe('routeUtils', () => {
           targetPluginId: 'catalog',
         }),
       );
+    });
+
+    it('should authenticate the caller and use their credentials as onBehalfOf when Authorization header is present', async () => {
+      const callerCredentials = {
+        $$type: '@backstage/BackstageCredentials',
+        principal: { type: 'user', userEntityRef: 'user:default/alice' },
+      } as unknown as Awaited<ReturnType<AuthService['authenticate']>>;
+      authenticateMock.mockResolvedValue(callerCredentials);
+
+      await getEntityFromRequest(
+        getRequest(mockedEntityRef, 'Bearer test-token-123'),
+        mockedClient,
+        mockedAuth,
+      );
+
+      expect(authenticateMock).toHaveBeenCalledWith('test-token-123');
+      expect(getPluginRequestTokenMock).toHaveBeenCalledWith({
+        onBehalfOf: callerCredentials,
+        targetPluginId: 'catalog',
+      });
+    });
+
+    it('should use getNoneCredentials as onBehalfOf when no Authorization header is present', async () => {
+      await getEntityFromRequest(
+        getRequest(mockedEntityRef),
+        mockedClient,
+        mockedAuth,
+      );
+
+      expect(authenticateMock).not.toHaveBeenCalled();
+      expect(getNoneCredentialsMock).toHaveBeenCalled();
+      expect(getPluginRequestTokenMock).toHaveBeenCalledWith({
+        onBehalfOf: defaultNoneCredentials,
+        targetPluginId: 'catalog',
+      });
     });
   });
 

--- a/plugins/dql-backend/src/utils/routeUtils.ts
+++ b/plugins/dql-backend/src/utils/routeUtils.ts
@@ -13,7 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { AuthService } from '@backstage/backend-plugin-api';
+import {
+  AuthService,
+  BackstageCredentials,
+} from '@backstage/backend-plugin-api';
 import { CatalogClient } from '@backstage/catalog-client';
 import { Entity } from '@backstage/catalog-model';
 import {
@@ -22,6 +25,36 @@ import {
   ExtendedEntity,
 } from '@dynatrace/backstage-plugin-dql-common';
 import { Request } from 'express';
+
+const TOKEN_PREFIX = 'Bearer ';
+
+const resolveCallerCredentials = async (
+  req: Request,
+  auth: AuthService,
+): Promise<BackstageCredentials> => {
+  const authorizationHeader = req.headers?.authorization;
+  const requestToken =
+    typeof authorizationHeader === 'string' &&
+    authorizationHeader.startsWith(TOKEN_PREFIX)
+      ? authorizationHeader.substring(TOKEN_PREFIX.length).trim()
+      : undefined;
+
+  if (
+    requestToken &&
+    typeof (auth as Partial<AuthService>).authenticate === 'function'
+  ) {
+    return await auth.authenticate(requestToken);
+  }
+
+  if (typeof (auth as Partial<AuthService>).getNoneCredentials === 'function') {
+    return await auth.getNoneCredentials();
+  }
+
+  return {
+    $$type: '@backstage/BackstageCredentials',
+    principal: { type: 'none' },
+  };
+};
 
 export const getEntityFromRequest = async (
   req: Request,
@@ -33,12 +66,14 @@ export const getEntityFromRequest = async (
     throw new Error('Invalid entity ref');
   }
 
+  const callerCredentials = await resolveCallerCredentials(req, auth);
+
   const { token } = await auth.getPluginRequestToken({
-    onBehalfOf: await auth.getOwnServiceCredentials(),
+    onBehalfOf: callerCredentials,
     targetPluginId: 'catalog',
   });
   if (!token) {
-    throw new Error(`Failed to get service token`);
+    throw new Error(`Failed to get catalog token`);
   }
 
   const entity = await client.getEntityByRef(entityRef, { token });

--- a/plugins/dql-backend/src/utils/routeUtils.ts
+++ b/plugins/dql-backend/src/utils/routeUtils.ts
@@ -26,18 +26,28 @@ import {
 } from '@dynatrace/backstage-plugin-dql-common';
 import { Request } from 'express';
 
-const TOKEN_PREFIX = 'Bearer ';
+const extractBearerToken = (
+  authorizationHeader: string | undefined,
+): string | undefined => {
+  if (typeof authorizationHeader !== 'string') {
+    return undefined;
+  }
+
+  const [scheme, ...credentialsParts] = authorizationHeader.trim().split(/\s+/);
+  if (!scheme || scheme.toLowerCase() !== 'bearer') {
+    return undefined;
+  }
+
+  const token = credentialsParts.join(' ').trim();
+  return token ? token : undefined;
+};
 
 const resolveCallerCredentials = async (
   req: Request,
   auth: AuthService,
 ): Promise<BackstageCredentials> => {
   const authorizationHeader = req.headers?.authorization;
-  const requestToken =
-    typeof authorizationHeader === 'string' &&
-    authorizationHeader.startsWith(TOKEN_PREFIX)
-      ? authorizationHeader.substring(TOKEN_PREFIX.length).trim()
-      : undefined;
+  const requestToken = extractBearerToken(authorizationHeader);
 
   if (
     requestToken &&


### PR DESCRIPTION
# Introduction

This PR improves the DQL backend request flow by making catalog entity resolution use request-scoped caller credentials when generating plugin tokens, instead of always relying on service-level credentials. It also refactors credential resolution into a dedicated helper to make the route utility logic easier to read and maintain.
### What changed
- Updated `getEntityFromRequest` in `plugins/dql-backend/src/utils/routeUtils.ts` to resolve caller credentials from the incoming request and use them for catalog token generation.
- Extracted credential resolution into a dedicated helper function (`resolveCallerCredentials`) to simplify control flow.
- Preserved existing entityRef validation and entity lookup error handling behavior.
- Added regression-oriented unit coverage in `plugins/dql-backend/src/utils/routeUtils.test.ts` aligned with request-scoped credential behavior.
### Why
- Aligns entity lookup with request context.
- Reduces implicit dependence on service credentials in this route path.
- Improves maintainability and testability of auth/token logic.