### PR TITLE
fix: mitigate CVE-2026-41242 in protobufjs, ref: CA-19172

### DIFF
--- a/package.json
+++ b/package.json
@@ -111,7 +111,8 @@
     "tar": "7.5.11",
     "immutable": "4.3.8",
     "flatted": "^3.4.2",
-    "undici": "^7.22.0"
+    "undici": "^7.22.0",
+    "protobufjs": "^7.5.5"
   },
   "lint-staged": {
     "*.{js,jsx,ts,tsx,mjs,cjs}": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -31369,9 +31369,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"protobufjs@npm:^7.0.0, protobufjs@npm:^7.2.5, protobufjs@npm:^7.2.6, protobufjs@npm:^7.3.2, protobufjs@npm:^7.4.0, protobufjs@npm:^7.5.3":
-  version: 7.5.4
-  resolution: "protobufjs@npm:7.5.4"
+"protobufjs@npm:^7.5.5":
+  version: 7.5.5
+  resolution: "protobufjs@npm:7.5.5"
   dependencies:
     "@protobufjs/aspromise": "npm:^1.1.2"
     "@protobufjs/base64": "npm:^1.1.2"
@@ -31385,7 +31385,7 @@ __metadata:
     "@protobufjs/utf8": "npm:^1.1.0"
     "@types/node": "npm:>=13.7.0"
     long: "npm:^5.0.0"
-  checksum: 10c0/913b676109ffb3c05d3d31e03a684e569be91f3bba8613da4a683d69d9dba948daa2afd7d2e7944d1aa6c417890c35d9d9a8883c1160affafb0f9670d59ef722
+  checksum: 10c0/3d48896a916761e3e60b52f80027eb4fba3f5a6e3f8461e04939db18812db2cb0db4c73d03e1134a960e99525ae1d236f076a0bc01273016f573b76f33ffbd47
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Fix CVE-2026-41242 by updating protobufjs to a non-vulnerable version via Yarn resolutions.

Updated root resolution to enforce protobufjs >=7.5.5 in package.json.