### PR TITLE
chore: update dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "basic-ftp": "5.3.0",
     "multer": "2.1.1",
     "underscore": "1.13.8",
-    "axios": "1.15.1",
+    "axios": "1.15.2",
     "koa": "2.16.4",
     "minimatch@npm:^3.0.4": "3.1.4",
     "minimatch@npm:^3.0.5": "3.1.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -16762,14 +16762,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"axios@npm:1.15.1":
-  version: 1.15.1
-  resolution: "axios@npm:1.15.1"
+"axios@npm:1.15.2":
+  version: 1.15.2
+  resolution: "axios@npm:1.15.2"
   dependencies:
     follow-redirects: "npm:^1.15.11"
     form-data: "npm:^4.0.5"
     proxy-from-env: "npm:^2.1.0"
-  checksum: 10c0/f8b5f3aa954cc1da283e32ad81882967a371dfec7dcc75174fcae93093daeb5399aec2ec587d04779f46b00ff1c297ac9edf3fa596452d6a3d455ce5b58093a4
+  checksum: 10c0/4eeae0feeaa7fdc1ef24f81f8b378fdadedf4aebdd6bf224484675160f8744cf17b9b0d1c215279979940f7e8ce463beffa2f713099612e428eac238515c81d5
   languageName: node
   linkType: hard
 
@@ -21927,12 +21927,12 @@ __metadata:
   linkType: hard
 
 "follow-redirects@npm:^1.0.0, follow-redirects@npm:^1.15.11":
-  version: 1.15.11
-  resolution: "follow-redirects@npm:1.15.11"
+  version: 1.16.0
+  resolution: "follow-redirects@npm:1.16.0"
   peerDependenciesMeta:
     debug:
       optional: true
-  checksum: 10c0/d301f430542520a54058d4aeeb453233c564aaccac835d29d15e050beb33f339ad67d9bddbce01739c5dc46a6716dbe3d9d0d5134b1ca203effa11a7ef092343
+  checksum: 10c0/a1e2900163e6f1b4d1ed5c221b607f41decbab65534c63fe7e287e40a5d552a6496e7d9d7d976fa4ba77b4c51c11e5e9f683f10b43011ea11e442ff128d0e181
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This pull request includes a minor dependency update in the `package.json` file.

- Dependency update:
  * Upgraded `axios` from version 1.15.1 to 1.15.2 in `package.json` - [CVE-2026-42044](https://www.cve.org/CVERecord?id=CVE-2026-42044)
  * Upgrade follow-redirects to 1.16.0 - [CVE-2026-40895](https://www.cve.org/CVERecord?id=CVE-2026-40895)