### PR TITLE
feat: Migrate kubernetes deployments query to Smartscape API

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -5,7 +5,7 @@ metadata:
   description: Backstage Demo instance.
   annotations:
     backstage.io/kubernetes-id: kubernetescustom
-    dynatrace.com/guardian-tags: ''
+    dynatrace.com/guardian-tags: 'service=my-service,stage=development,novalue'
   dynatrace:
     queries:
       - id: Error Logs

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -5,7 +5,7 @@ metadata:
   description: Backstage Demo instance.
   annotations:
     backstage.io/kubernetes-id: kubernetescustom
-    dynatrace.com/guardian-tags: 'service=my-service,stage=development,novalue'
+    dynatrace.com/guardian-tags: ''
   dynatrace:
     queries:
       - id: Error Logs

--- a/plugins/dql-backend/src/service/queries.test.ts
+++ b/plugins/dql-backend/src/service/queries.test.ts
@@ -112,6 +112,46 @@ describe('queries', () => {
       );
     });
 
+    it('should query smartscapeNodes with the correct Kubernetes workload types', () => {
+      const query = dynatraceQueries[DynatraceQueryKeys.KUBERNETES_DEPLOYMENTS](
+        getEntity({ 'backstage.io/kubernetes-id': 'myapp' }),
+        defaultApiConfig,
+      );
+
+      expect(query).toContain('smartscapeNodes "K8S_*"');
+      expect(query).toContain('"K8S_CRONJOB", "K8S_DAEMONSET", "K8S_DEPLOYMENT", "K8S_STATEFULSET"');
+    });
+
+    it('should inject the environment URL as a DQL field', () => {
+      const query = dynatraceQueries[DynatraceQueryKeys.KUBERNETES_DEPLOYMENTS](
+        getEntity({ 'backstage.io/kubernetes-id': 'myapp' }),
+        { environmentName: 'myenv', environmentUrl: 'https://example.dynatrace.com' },
+      );
+
+      expect(query).toContain('| fieldsAdd environmentUrl = "https://example.dynatrace.com"');
+    });
+
+    it('should build WorkloadLink using the Smartscape URL format', () => {
+      const query = dynatraceQueries[DynatraceQueryKeys.KUBERNETES_DEPLOYMENTS](
+        getEntity({ 'backstage.io/kubernetes-id': 'myapp' }),
+        defaultApiConfig,
+      );
+
+      expect(query).toContain('/ui/intent/dynatrace.kubernetes/view-entity-dt.smartscape.');
+      expect(query).toContain('"""{"nodeId":""""');
+    });
+
+    it('should select the expected output columns', () => {
+      const query = dynatraceQueries[DynatraceQueryKeys.KUBERNETES_DEPLOYMENTS](
+        getEntity({ 'backstage.io/kubernetes-id': 'myapp' }),
+        defaultApiConfig,
+      );
+
+      expect(query).toContain(
+        '| fields Workload, Cluster, Namespace, Problems, Vulnerabilities, Logs, Environment, Version',
+      );
+    });
+
     it('should sanitize DQL in kubernetes-id annotation', () => {
       // act
       const query = dynatraceQueries[DynatraceQueryKeys.KUBERNETES_DEPLOYMENTS](

--- a/plugins/dql-backend/src/service/queries.test.ts
+++ b/plugins/dql-backend/src/service/queries.test.ts
@@ -128,6 +128,24 @@ describe('queries', () => {
       );
     });
 
+    it('should contain literal DQL escape sequences in the LogLink field', () => {
+      const query = dynatraceQueries[DynatraceQueryKeys.KUBERNETES_DEPLOYMENTS](
+        getEntity({ 'backstage.io/kubernetes-id': 'myapp' }),
+        defaultApiConfig,
+      );
+
+      // LogLink concat must carry literal \n and \" for DQL to interpret them on the Dynatrace side.
+      // Using '"""\\n' in the JS test string matches the two-char sequence backslash+n in the query.
+      expect(query).toContain('"""\\n| filter k8s.cluster.name');
+      expect(query).toContain('"""\\n| filter k8s.namespace.name');
+      expect(query).toContain('"""\\n| filter k8s.workload.name');
+      expect(query).toContain('\\"is_part_of\\"');
+      expect(query).toContain('"""\\n | filter target_id');
+      expect(query).toContain('\\"K8S_POD\\"');
+      expect(query).toContain('\\"K8S_POD\\"\\n | fields k8s.pod.name');
+      expect(query).toContain('"""\\n| sort timestamp desc"""');
+    });
+
     it('should sanitize DQL in kubernetes-namespace annotation', () => {
       // act
       const query = dynatraceQueries[DynatraceQueryKeys.KUBERNETES_DEPLOYMENTS](

--- a/plugins/dql-backend/src/service/queries.ts
+++ b/plugins/dql-backend/src/service/queries.ts
@@ -27,30 +27,6 @@ interface ApiConfig {
   environmentUrl: string;
 }
 
-const getKubernetesLogLink = (idField: string, apiConfig: ApiConfig) => {
-  // Resulting DQL:
-  // fetch logs
-  // | filter dt.entity.cloud_application == "CLOUD_APPLICATION-XY" or in(dt.entity.cloud_application, "CLOUD_APPLICATION-XY") or in(dt.entity.cloud_application_instance, classicEntitySelector("type(CLOUD_APPLICATION_INSTANCE),fromRelationShip.IS_INSTANCE_OF(type(CLOUD_APPLICATION),entityId(\"CLOUD_APPLICATION-XY\"))"))
-  // | sort timestamp desc
-  const concatArray = [
-    `concat("${apiConfig.environmentUrl}"`,
-    `"/ui/apps/dynatrace.notebooks/intent/view-query#${encodeURIComponent(
-      '{"dt.query":"fetch logs\\n| filter dt.entity.cloud_application == \\"',
-    )}"`,
-    idField,
-    `"${encodeURIComponent('\\" or in(dt.entity.cloud_application, \\"')}"`,
-    idField,
-    `"${encodeURIComponent(
-      '\\") or in(dt.entity.cloud_application_instance, classicEntitySelector(\\"type(CLOUD_APPLICATION_INSTANCE),fromRelationShip.IS_INSTANCE_OF(type(CLOUD_APPLICATION),entityId(\\\\\\"',
-    )}"`,
-    idField,
-    `"${encodeURIComponent(
-      '\\\\\\"))\\"))\\n| sort timestamp desc","title":"Logs"}',
-    )}")`,
-  ];
-  return concatArray.join(',');
-};
-
 export const isValidDynatraceQueryKey = (
   key: string,
 ): key is DynatraceQueryKeys => key in dynatraceQueries;
@@ -87,42 +63,11 @@ export const dynatraceQueries: Record<
       );
     }
 
-    const dql1= `
-    fetch dt.entity.cloud_application, from: -10m
-    | fields id,
-        name = entity.name,
-        workload.labels = cloudApplicationLabels,
-        cluster.id = clustered_by[dt.entity.kubernetes_cluster],
-        namespace.id = belongs_to[dt.entity.cloud_application_namespace]
-    | sort upper(name) asc    
-    | lookup [fetch dt.entity.kubernetes_cluster, from: -10m | fields id, clusterName = entity.name],sourceField:cluster.id, lookupField:id, fields:{clusterName}
-    | lookup [fetch dt.entity.cloud_application_namespace, from: -10m | fields id, namespaceName = entity.name], sourceField:namespace.id, lookupField:id, fields:{namespaceName}
-    | fieldsAdd Workload = record({type="link", text=name, url=concat("${
-      apiConfig.environmentUrl
-    }/ui/intent/dynatrace.kubernetes/entityKubernetesWorkload/#%7B%22dt.entity.cloud_application%22%3A%22", id,"%22%7D")})
-    | fieldsAdd Cluster = clusterName, Namespace = namespaceName
-    | fieldsRemove clusterName, namespaceName
-    | lookup [fetch events, from: -30m | filter event.kind == "DAVIS_PROBLEM" | fieldsAdd affected_entity_id = affected_entity_ids[0] | summarize collectDistinct(event.status), by:{display_id, affected_entity_id}, alias:problem_status | filter NOT in(problem_status, "CLOSED") | summarize Problems = count(), by:{affected_entity_id}], sourceField:id, lookupField:affected_entity_id, fields:{Problems}
-    | fieldsAdd Problems=coalesce(Problems,0)
-    | lookup [ fetch security.events, from: -30m | filter event.kind=="SECURITY_EVENT" | filter event.category=="VULNERABILITY_MANAGEMENT" | filter event.provider=="Dynatrace" | filter event.type=="VULNERABILITY_STATE_REPORT_EVENT" | filter in(vulnerability.stack,{"CODE_LIBRARY","SOFTWARE","CONTAINER_ORCHESTRATION"}) | filter event.level=="ENTITY" | summarize { workloadId=arrayFirst(takeFirst(related_entities.kubernetes_workloads.ids)), vulnerability.stack=takeFirst(vulnerability.stack)}, by: {vulnerability.id, affected_entity.id} | summarize { Vulnerabilities=count() }, by: {workloadId}], sourceField:id, lookupField:workloadId, fields:{Vulnerabilities}
-    | fieldsAdd Vulnerabilities=coalesce(Vulnerabilities,0)
-    // ${filterKubernetesId} 
-    ${filterNamespace} 
-    ${filterLabel}
-    | fieldsAdd Logs = record({type="link", text="Show logs", url=${getKubernetesLogLink(
-      'id',
-      apiConfig,
-    )}})
-    | fieldsAdd Environment = "${apiConfig.environmentName}"
-    | fieldsAdd Version = coalesce(workload.labels[\`app.kubernetes.io/version\`], "")
-    | fieldsRemove id, name, workload.labels, cluster.id, namespace.id`;
-    console.log(dql1);
-
-const dql = `smartscapeNodes "K8S_*", from: -10m
+    const dql = `smartscapeNodes "K8S_*", from: -10m
 | filter in(type, {"K8S_CRONJOB", "K8S_DAEMONSET", "K8S_DEPLOYMENT", "K8S_STATEFULSET"})
 | fields id, id_classic, type, name, Cluster = k8s.cluster.name, Namespace = k8s.namespace.name, workload.labels = \`tags:k8s.labels\`
 | sort upper(name) asc
-// ${filterKubernetesId} 
+${filterKubernetesId} 
 ${filterNamespace} 
 ${filterLabel}
 | fieldsAdd environmentUrl = "${apiConfig.environmentUrl}"
@@ -134,13 +79,13 @@ ${filterLabel}
   "/ui/apps/dynatrace.notebooks/intent/view-query#",
   """{"dt.query":"""",
   "fetch logs",
-  concat("""\n| filter k8s.cluster.name == \"""", Cluster, """\""""),
-  concat("""\n| filter k8s.namespace.name == \"""", Namespace, """\""""),
-  concat("""\n| filter k8s.workload.name == \"""", name, """\""""),
-  """\n or in(k8s.pod.name, lookup([smartscapeEdges \"is_part_of\"""",
-  concat("""\n  | filter target_id == toSmartscapeId(\"""", toString(id), """\")"""),       
-  """ and source_type == \"K8S_POD\"\n  | fields k8s.pod.name = getNodeName(source_id)], sourceField:k8s.pod.name, lookupField:k8s.pod.name)[k8s.pod.name])""",
-  """\n| sort timestamp desc""",
+  concat("""\\n| filter k8s.cluster.name == \\"""", Cluster, """\\""""),
+  concat("""\\n| filter k8s.namespace.name == \\"""", Namespace, """\\""""),
+  concat("""\\n| filter k8s.workload.name == \\"""", name, """\\""""),
+  """\\n or in(k8s.pod.name, lookup([smartscapeEdges \\"is_part_of\\"""",
+  concat("""\\n | filter target_id == toSmartscapeId(\\"""", toString(id), """\\")"""),
+  """ and source_type == \\"K8S_POD\\"\\n | fields k8s.pod.name = getNodeName(source_id)], sourceField:k8s.pod.name, lookupField:k8s.pod.name)[k8s.pod.name])""",
+  """\\n| sort timestamp desc""",
   """","title":"Logs"}"""
 )
 | fieldsAdd Logs = record({type="link", text="Show logs", url=LogLink})
@@ -151,7 +96,6 @@ ${filterLabel}
 | fieldsAdd Environment = "${apiConfig.environmentName}"
 | fields Workload, Cluster, Namespace, Problems, Vulnerabilities, Logs, Environment, Version
 `
-console.log(dql);
     return dql;
   },
   [DynatraceQueryKeys.SRG_VALIDATIONS]: (entity, apiConfig) => {

--- a/plugins/dql-backend/src/service/queries.ts
+++ b/plugins/dql-backend/src/service/queries.ts
@@ -67,8 +67,8 @@ export const dynatraceQueries: Record<
 | filter in(type, {"K8S_CRONJOB", "K8S_DAEMONSET", "K8S_DEPLOYMENT", "K8S_STATEFULSET"})
 | fields id, id_classic, type, name, Cluster = k8s.cluster.name, Namespace = k8s.namespace.name, workload.labels = \`tags:k8s.labels\`
 | sort upper(name) asc
-${filterKubernetesId} 
-${filterNamespace} 
+${filterKubernetesId}
+${filterNamespace}
 ${filterLabel}
 | fieldsAdd environmentUrl = "${apiConfig.environmentUrl}"
 | fieldsAdd Version = coalesce(workload.labels[\`app.kubernetes.io/version\`], "")

--- a/plugins/dql-backend/src/service/queries.ts
+++ b/plugins/dql-backend/src/service/queries.ts
@@ -87,7 +87,7 @@ export const dynatraceQueries: Record<
       );
     }
 
-    return `
+    const dql1= `
     fetch dt.entity.cloud_application, from: -10m
     | fields id,
         name = entity.name,
@@ -106,7 +106,7 @@ export const dynatraceQueries: Record<
     | fieldsAdd Problems=coalesce(Problems,0)
     | lookup [ fetch security.events, from: -30m | filter event.kind=="SECURITY_EVENT" | filter event.category=="VULNERABILITY_MANAGEMENT" | filter event.provider=="Dynatrace" | filter event.type=="VULNERABILITY_STATE_REPORT_EVENT" | filter in(vulnerability.stack,{"CODE_LIBRARY","SOFTWARE","CONTAINER_ORCHESTRATION"}) | filter event.level=="ENTITY" | summarize { workloadId=arrayFirst(takeFirst(related_entities.kubernetes_workloads.ids)), vulnerability.stack=takeFirst(vulnerability.stack)}, by: {vulnerability.id, affected_entity.id} | summarize { Vulnerabilities=count() }, by: {workloadId}], sourceField:id, lookupField:workloadId, fields:{Vulnerabilities}
     | fieldsAdd Vulnerabilities=coalesce(Vulnerabilities,0)
-    ${filterKubernetesId} 
+    // ${filterKubernetesId} 
     ${filterNamespace} 
     ${filterLabel}
     | fieldsAdd Logs = record({type="link", text="Show logs", url=${getKubernetesLogLink(
@@ -116,6 +116,43 @@ export const dynatraceQueries: Record<
     | fieldsAdd Environment = "${apiConfig.environmentName}"
     | fieldsAdd Version = coalesce(workload.labels[\`app.kubernetes.io/version\`], "")
     | fieldsRemove id, name, workload.labels, cluster.id, namespace.id`;
+    console.log(dql1);
+
+const dql = `smartscapeNodes "K8S_*", from: -10m
+| filter in(type, {"K8S_CRONJOB", "K8S_DAEMONSET", "K8S_DEPLOYMENT", "K8S_STATEFULSET"})
+| fields id, id_classic, type, name, Cluster = k8s.cluster.name, Namespace = k8s.namespace.name, workload.labels = \`tags:k8s.labels\`
+| sort upper(name) asc
+// ${filterKubernetesId} 
+${filterNamespace} 
+${filterLabel}
+| fieldsAdd environmentUrl = "${apiConfig.environmentUrl}"
+| fieldsAdd Version = coalesce(workload.labels[\`app.kubernetes.io/version\`], "")
+| fieldsAdd WorkloadLink = concat(environmentUrl, "/ui/intent/dynatrace.kubernetes/view-entity-dt.smartscape.", lower(type), "#", """{"nodeId":"""", toString(id) ,""""}""")
+| fieldsAdd Workload = record({type="link", text=name, url=WorkloadLink})
+| fieldsAdd LogLink = concat(
+  environmentUrl,
+  "/ui/apps/dynatrace.notebooks/intent/view-query#",
+  """{"dt.query":"""",
+  "fetch logs",
+  concat("""\n| filter k8s.cluster.name == \"""", Cluster, """\""""),
+  concat("""\n| filter k8s.namespace.name == \"""", Namespace, """\""""),
+  concat("""\n| filter k8s.workload.name == \"""", name, """\""""),
+  """\n or in(k8s.pod.name, lookup([smartscapeEdges \"is_part_of\"""",
+  concat("""\n  | filter target_id == toSmartscapeId(\"""", toString(id), """\")"""),       
+  """ and source_type == \"K8S_POD\"\n  | fields k8s.pod.name = getNodeName(source_id)], sourceField:k8s.pod.name, lookupField:k8s.pod.name)[k8s.pod.name])""",
+  """\n| sort timestamp desc""",
+  """","title":"Logs"}"""
+)
+| fieldsAdd Logs = record({type="link", text="Show logs", url=LogLink})
+| lookup [fetch events, from: -30m | filter event.kind == "DAVIS_PROBLEM" | fieldsAdd affected_entity_id = smartscape.affected_entities[0][id] | summarize collectDistinct(event.status), by:{display_id, affected_entity_id}, alias:problem_status | filter NOT in(problem_status, "CLOSED") | summarize Problems = count(), by:{affected_entity_id}], sourceField:id, lookupField:affected_entity_id, fields:{Problems}
+| fieldsAdd Problems=coalesce(Problems,0)
+| lookup [ fetch security.events, from: -30m | filter event.kind=="SECURITY_EVENT" | filter event.category=="VULNERABILITY_MANAGEMENT" | filter event.provider=="Dynatrace" | filter event.type=="VULNERABILITY_STATE_REPORT_EVENT" | filter in(vulnerability.stack,{"CODE_LIBRARY","SOFTWARE","CONTAINER_ORCHESTRATION"}) | filter event.level=="ENTITY" | summarize { workloadId=arrayFirst(takeFirst(related_entities.kubernetes_workloads.ids)), vulnerability.stack=takeFirst(vulnerability.stack)}, by: {vulnerability.id, affected_entity.id} | summarize { Vulnerabilities=count() }, by: {workloadId}], sourceField:id_classic, lookupField:workloadId, fields:{Vulnerabilities}
+| fieldsAdd Vulnerabilities=coalesce(Vulnerabilities,0)
+| fieldsAdd Environment = "${apiConfig.environmentName}"
+| fields Workload, Cluster, Namespace, Problems, Vulnerabilities, Logs, Environment, Version
+`
+console.log(dql);
+    return dql;
   },
   [DynatraceQueryKeys.SRG_VALIDATIONS]: (entity, apiConfig) => {
     const annotationName = 'dynatrace.com/guardian-tags';


### PR DESCRIPTION
### What changed

Replaces the `KUBERNETES_DEPLOYMENTS` DQL query from a `fetch dt.entity.cloud_application` entity-based approach to `smartscapeNodes "K8S_*"`, which returns Kubernetes workloads (Deployments, DaemonSets, StatefulSets, CronJobs) directly from the Smartscape topology.

**Key changes in `queries.ts`:**
- Removed `getKubernetesLogLink()` helper — the log link is now built inline within the DQL query using `concat` and triple-quoted string literals, keeping all URL construction on the Dynatrace side.
- `WorkloadLink` now uses the Smartscape intent URL (`/ui/intent/dynatrace.kubernetes/view-entity-dt.smartscape.<type>`).
- `LogLink` constructs a Dynatrace Notebooks deep-link with an inline DQL query via `concat`.

**Escape sequence fix (⚠️ needs reviewer attention):**  
The inline DQL uses triple-quoted strings (`"""..."""`) containing `\n` and `\"` escape sequences. These must survive as literal two-character sequences in the string sent to Dynatrace — but TypeScript's template literal parser consumes single backslashes. All backslashes in the `LogLink` concat block are doubled (`\\n`, `\\"`) so TypeScript produces the correct literal characters.

### Tests added (`queries.test.ts`)
- Asserts `smartscapeNodes "K8S_*"` data source and correct workload type filter
- Asserts `environmentUrl` field is injected into the query
- Asserts `WorkloadLink` uses the Smartscape URL format
- Asserts output `fields` column selection
- Asserts `LogLink` DQL concat carries literal `\n` and `\"` sequences (not actual newlines/quotes)

### Reviewer checklist
- [ ] Review the doubled-backslash escaping in the `LogLink` concat block (~lines 82–89 of `queries.ts`) — this is the most non-obvious part
- [ ] Confirm `k8s.cluster.name`, `k8s.namespace.name`, `k8s.workload.name` Smartscape properties are available in target environments
- [ ] Verify the new `WorkloadLink` and `LogLink` URL formats open correctly in Dynatrace

### Screenshot
<img width="1579" height="1141" alt="image" src="https://github.com/user-attachments/assets/f21eb3fc-35ce-482a-959e-5a91ceeb7169" />
