### PR TITLE
chore: bump shell-quote dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -118,6 +118,7 @@
     "uuid@npm:^8.3.2": "9.0.1",
     "brace-expansion@npm:^5.0.2": "5.0.6",
     "brace-expansion@npm:^5.0.5": "5.0.6",
+    "shell-quote": "1.8.4",
     "@protobufjs/inquire@npm:^1.1.2": "patch:@protobufjs/inquire@npm%3A1.1.2#~/.yarn/patches/@protobufjs-inquire-npm-1.1.2-d8a203d287.patch"
   },
   "lint-staged": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -31625,10 +31625,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"shell-quote@npm:1.8.3, shell-quote@npm:^1.7.3, shell-quote@npm:^1.8.1, shell-quote@npm:^1.8.3":
-  version: 1.8.3
-  resolution: "shell-quote@npm:1.8.3"
-  checksum: 10c0/bee87c34e1e986cfb4c30846b8e6327d18874f10b535699866f368ade11ea4ee45433d97bf5eada22c4320c27df79c3a6a7eb1bf3ecfc47f2c997d9e5e2672fd
+"shell-quote@npm:1.8.4":
+  version: 1.8.4
+  resolution: "shell-quote@npm:1.8.4"
+  checksum: 10c0/86c93678bc394cb81f5ddcdc87df9c95d279ef9652775cd1cd1eed361404169a8d8cbaacaeed232ab09919e36ee1e5363863570390d78571f8c22b7f6312fb40
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
 - Pin `shell-quote` to `1.8.4` via root resolution to patch CVE-2026-9277 (transitive depependency `concurrently@9.2.1` was the only blocker, as it pins`1.8.3`).