### PR TITLE
feat: Extend DQL sanitizer

### DIFF
--- a/plugins/dql-backend/src/utils/dqlSanitizer.test.ts
+++ b/plugins/dql-backend/src/utils/dqlSanitizer.test.ts
@@ -24,6 +24,14 @@ describe('dql-sanitizer', () => {
     expect(escaped).toBe('a\\\\b\\"c');
   });
 
+  it('should escape backticks alongside backslashes and quotes', () => {
+    // act
+    const escaped = sanitizeDqlString('key`value', 'some-annotation');
+
+    // assert
+    expect(escaped).toBe('key\\`value');
+  });
+
   it('should fail for control characters in DQL strings', () => {
     // act, assert
     expect(() => sanitizeDqlString('line1\nline2', 'some-annotation')).toThrow(

--- a/plugins/dql-backend/src/utils/dqlSanitizer.ts
+++ b/plugins/dql-backend/src/utils/dqlSanitizer.ts
@@ -27,5 +27,5 @@ export const sanitizeDqlString = (
   annotationName: string,
 ): string => {
   assertNoControlCharacters(value, annotationName);
-  return value.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+  return value.replace(/\\/g, '\\\\').replace(/"/g, '\\"').replace(/`/g, '\\`');
 };

--- a/plugins/dql-backend/src/utils/labelSelectorParser.test.ts
+++ b/plugins/dql-backend/src/utils/labelSelectorParser.test.ts
@@ -52,9 +52,21 @@ describe('label-parser', () => {
     expect(filter).toBe('');
   });
 
+  it('should escape backticks in label keys', () => {
+    // act
+    const filter = generateKubernetesSelectorFilter(
+      'label=`value`',
+    );
+
+    // assert
+    expect(filter).toBe(
+      '| filter workload.labels[`label`] == \"\\`value\\`\"',
+    );
+  });
+
   it('should sanitize input', () => {
     // act
-   const filter = generateKubernetesSelectorFilter('labe"l1,label2="value2"');
+    const filter = generateKubernetesSelectorFilter('labe"l1,label2="value2"');
 
     // assert
     expect(filter).toBe(


### PR DESCRIPTION
## Summary

- Extended `sanitizeDqlString` to escape backtick characters alongside the existing backslash and double-quote escaping, completing the set of characters that require escaping in DQL string and identifier contexts
- Added test coverage for backtick escaping in `dqlSanitizer.test.ts` and `labelSelectorParser.test.ts`

