### PR TITLE
chore(deps): fix security vulnerabilities (20260706)

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,6 +89,7 @@
     "brace-expansion@npm:^1.1.7": "5.0.7",
     "brace-expansion@npm:^2.0.1": "5.0.7",
     "brace-expansion@npm:^2.0.2": "5.0.7",
+    "minimatch@npm:3.1.2": "3.1.5",
     "minimatch@npm:^5.0.1": "5.1.8",
     "minimatch@npm:^5.1.0": "5.1.8",
     "minimatch@npm:^7.4.3": "7.4.8",

--- a/package.json
+++ b/package.json
@@ -86,7 +86,9 @@
     "underscore": "1.13.8",
     "axios": "1.16.1",
     "koa": "2.16.4",
-    "brace-expansion@npm:^1.1.7": "2.0.3",
+    "brace-expansion@npm:^1.1.7": "5.0.7",
+    "brace-expansion@npm:^2.0.1": "5.0.7",
+    "brace-expansion@npm:^2.0.2": "5.0.7",
     "minimatch@npm:^5.0.1": "5.1.8",
     "minimatch@npm:^5.1.0": "5.1.8",
     "minimatch@npm:^7.4.3": "7.4.8",
@@ -124,7 +126,9 @@
     "@grpc/grpc-js": "1.14.4",
     "form-data@npm:^4.0.0": "4.0.6",
     "form-data@npm:^4.0.5": "4.0.6",
-    "ws": "8.21.0"
+    "ws": "8.21.0",
+    "js-cookie": "3.0.8",
+    "linkify-it": "5.0.2"
   },
   "lint-staged": {
     "*.{js,jsx,ts,tsx,mjs,cjs}": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -26025,21 +26025,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"minimatch@npm:3.1.2":
-  version: 3.1.2
-  resolution: "minimatch@npm:3.1.2"
-  dependencies:
-    brace-expansion: "npm:^1.1.7"
-  checksum: 10c0/0262810a8fc2e72cca45d6fd86bd349eee435eb95ac6aa45c9ea2180e7ee875ef44c32b55b5973ceabe95ea12682f6e3725cbb63d7a2d1da3ae1163c8b210311
-  languageName: node
-  linkType: hard
-
 "minimatch@npm:3.1.4":
   version: 3.1.4
   resolution: "minimatch@npm:3.1.4"
   dependencies:
     brace-expansion: "npm:^1.1.7"
   checksum: 10c0/868aab7e5f52570107eb283f021383be111cfeee0817a615f2a9ffe61fdc8fb86d535b9bf169fb8882261e7cb9da22b4d7b6f8b3402037f63558bab173f82212
+  languageName: node
+  linkType: hard
+
+"minimatch@npm:3.1.5, minimatch@npm:^3.0.4, minimatch@npm:^3.0.5, minimatch@npm:^3.1.1, minimatch@npm:^3.1.2":
+  version: 3.1.5
+  resolution: "minimatch@npm:3.1.5"
+  dependencies:
+    brace-expansion: "npm:^1.1.7"
+  checksum: 10c0/2ecbdc0d33f07bddb0315a8b5afbcb761307a8778b48f0b312418ccbced99f104a2d17d8aca7573433c70e8ccd1c56823a441897a45e384ea76ef401a26ace70
   languageName: node
   linkType: hard
 
@@ -26076,15 +26076,6 @@ __metadata:
   dependencies:
     brace-expansion: "npm:^5.0.5"
   checksum: 10c0/6bb058bd6324104b9ec2f763476a35386d05079c1f5fe4fbf1f324a25237cd4534d6813ecd71f48208f4e635c1221899bef94c3c89f7df55698fe373aaae20fd
-  languageName: node
-  linkType: hard
-
-"minimatch@npm:^3.0.4, minimatch@npm:^3.0.5, minimatch@npm:^3.1.1, minimatch@npm:^3.1.2":
-  version: 3.1.5
-  resolution: "minimatch@npm:3.1.5"
-  dependencies:
-    brace-expansion: "npm:^1.1.7"
-  checksum: 10c0/2ecbdc0d33f07bddb0315a8b5afbcb761307a8778b48f0b312418ccbced99f104a2d17d8aca7573433c70e8ccd1c56823a441897a45e384ea76ef401a26ace70
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -15021,13 +15021,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"balanced-match@npm:^1.0.0":
-  version: 1.0.2
-  resolution: "balanced-match@npm:1.0.2"
-  checksum: 10c0/9308baf0a7e4838a82bbfd11e01b1cb0f0cf2893bc1676c27c2a8c0e70cbae1c59120c3268517a8ae7fb6376b4639ef81ca22582611dbee4ed28df945134aaee
-  languageName: node
-  linkType: hard
-
 "balanced-match@npm:^4.0.2":
   version: 4.0.4
   resolution: "balanced-match@npm:4.0.4"
@@ -15304,15 +15297,6 @@ __metadata:
   version: 2.13.1
   resolution: "bowser@npm:2.13.1"
   checksum: 10c0/a57ef440c68e80ce736b95017e13f65d1476cdfa3cae10e0958ab71a8ed3e804aad761c5809b98fbaeaacd8cd1986d46ee7c317937c601897c9b1d17971bc8d1
-  languageName: node
-  linkType: hard
-
-"brace-expansion@npm:2.0.3, brace-expansion@npm:^2.0.1, brace-expansion@npm:^2.0.2":
-  version: 2.0.3
-  resolution: "brace-expansion@npm:2.0.3"
-  dependencies:
-    balanced-match: "npm:^1.0.0"
-  checksum: 10c0/468436c9b2fa6f9e64d0cff8784b21300677571a7196e258593e95e7c3db9973a80fbafdb0f01404d5d298a04dc666eae1fc3c9052e2edbb9f2510541deeddfe
   languageName: node
   linkType: hard
 
@@ -23618,10 +23602,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"js-cookie@npm:^2.2.1":
-  version: 2.2.1
-  resolution: "js-cookie@npm:2.2.1"
-  checksum: 10c0/ee67fc0f8495d0800b851910b5eb5bf49d3033adff6493d55b5c097ca6da46f7fe666b10e2ecb13cfcaf5b88d71c205ce00a7e646de791689bfd053bbb36a376
+"js-cookie@npm:3.0.8":
+  version: 3.0.8
+  resolution: "js-cookie@npm:3.0.8"
+  checksum: 10c0/421912a4a55535bda32b3059835864e1182c3af5b4516df00a060edc1fa5a53d38bb8d5a91d5d305e396206f4fd11e829f17850aa5aa8164118c04d8ebf1ff5d
   languageName: node
   linkType: hard
 
@@ -24505,12 +24489,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"linkify-it@npm:^5.0.0":
-  version: 5.0.0
-  resolution: "linkify-it@npm:5.0.0"
+"linkify-it@npm:5.0.2":
+  version: 5.0.2
+  resolution: "linkify-it@npm:5.0.2"
   dependencies:
     uc.micro: "npm:^2.0.0"
-  checksum: 10c0/ff4abbcdfa2003472fc3eb4b8e60905ec97718e11e33cca52059919a4c80cc0e0c2a14d23e23d8c00e5402bc5a885cdba8ca053a11483ab3cc8b3c7a52f88e2d
+  checksum: 10c0/dd70b1735a13d41a2cff0a058ac3771166038f23f6aff004dd53873cf985c64b107902fe0b544a5b3d1ff6e63249cf9c648fb3ae9f285481db48f56887adb0d6
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

Security vulnerability fixes for 3 HIGH severity CVEs plus 2 additional Snyk findings. All fixes applied as `resolutions` in the root `package.json` — no direct dependency changes.

### CVE fixes

| Package | From | To | CVE | Type |
|---|---|---|---|---|
| `brace-expansion` | 2.0.3 | **5.0.7** | CVE-2026-13149 | Inefficient Algorithmic Complexity |
| `js-cookie` | 2.2.1 | **3.0.8** | CVE-2026-46625 | Prototype Pollution |
| `linkify-it` | 5.0.0 | **5.0.2** | CVE-2026-48801 | ReDoS |

### Snyk fixes

| Package | From | To | Advisory | Type |
|---|---|---|---|---|
| `minimatch` | 3.1.2 | **3.1.5** | SNYK-JS-MINIMATCH-15309438 / SNYK-JS-MINIMATCH-15353389 | ReDoS + Inefficient Algorithmic Complexity |

## False-positive analysis

**`brace-expansion` (CVE-2026-13149):** The scanner reported version `1.1.13` as vulnerable. This exact version was **not installed** — an existing resolution already redirected `^1.1.7` to `2.0.3`. However, `2.0.3` is also below the fixed threshold (`5.0.7`), so it was still potentially exploitable. The resolution was updated to `5.0.7` for all `1.x` and `2.x` ranges.

**`js-cookie` (CVE-2026-46625):** Version `2.2.1` **was installed** (transitive via `react-use@17.6.0`). Not a false positive. Fixed by adding a global resolution to `3.0.8`.

**`linkify-it` (CVE-2026-48801):** Version `5.0.0` **was installed** (transitive via `markdown-it@14.1.0` ← `@graphiql/react@0.29.0`). Not a false positive. Fixed by resolution to `5.0.2`.

**`minimatch@3.1.2` (Snyk):** `@stoplight/spectral-core@1.20.0` pins the exact version `3.1.2`. Added resolution `"minimatch@npm:3.1.2": "3.1.5"` to redirect it to the patched version. Introduced via: `@backstage/plugin-api-docs > @asyncapi/react-component > @asyncapi/avro-schema-parser > @asyncapi/parser > @stoplight/spectral-core > minimatch@3.1.2`.

## Test plan

- [x] `yarn clean` ✓
- [x] `yarn lint:all` ✓
- [x] `yarn tsc:full` ✓
- [x] `yarn test:all` ✓ — 23 suites, 125 tests, all passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)