### PR TITLE
chore: bump dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -112,7 +112,7 @@
     "tar": "7.5.21",
     "immutable": "4.3.9",
     "flatted": "^3.4.2",
-    "undici": "7.28.0",
+    "undici": "7.29.0",
     "protobufjs": "7.6.5",
     "js-yaml@npm:^3.6.1": "3.15.0",
     "js-yaml@npm:^3.8.3": "3.15.0",

--- a/plugins/dql-backend/package.json
+++ b/plugins/dql-backend/package.json
@@ -39,7 +39,7 @@
     "@types/express": "4.17.25",
     "express": "4.22.2",
     "express-promise-router": "^4.1.0",
-    "undici": "7.28.0",
+    "undici": "7.29.0",
     "winston": "^3.2.1",
     "yn": "5.1.0",
     "zod": "4.4.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5537,7 +5537,7 @@ __metadata:
     express: "npm:4.22.2"
     express-promise-router: "npm:^4.1.0"
     msw: "npm:2.14.6"
-    undici: "npm:7.28.0"
+    undici: "npm:7.29.0"
     winston: "npm:^3.2.1"
     yn: "npm:5.1.0"
     zod: "npm:4.4.3"
@@ -33656,10 +33656,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"undici@npm:7.28.0":
-  version: 7.28.0
-  resolution: "undici@npm:7.28.0"
-  checksum: 10c0/fe781983a26098795e99bb1f64906cbb7d0bcaa029a26baade007b53ea67f2631d189b8f9671a31f4c8d0cb3773b7559608628ba54452fef51fec90e7c78bb0d
+"undici@npm:7.29.0":
+  version: 7.29.0
+  resolution: "undici@npm:7.29.0"
+  checksum: 10c0/85ea96e91e7f3de24de678cbbc54230fdd641a3b0643005f2aef044af1f1a2db8fbecb88b28e6fa78bb41ffeafda4479b57075b6b6ab92beac4b7b5ab53f9b10
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
 ---
  ### Introduction
     
  Bumps undici from 7.28.0 to 7.29.0 to address CVE-2026-14643 (Interpretation Conflict
  vulnerability). See the undici 7.29.0 release notes for details.

###   Technical solution before this PR

  undici was pinned to 7.28.0 both as a workspace resolution in the root package.json and as
  a direct dependency of the dql-backend plugin. Version 7.28.0 is affected by
  CVE-2026-14643.

###   Technical solution after this PR

  Both pins are updated to 7.29.0, which contains the fix for CVE-2026-14643. The resolution
  in the root package.json ensures no transitive dependency can pull in the vulnerable
  version across the monorepo.
